### PR TITLE
Update Rust API (async / .await)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ keywords = ["owasp", "zap", "zaproxy", "api"]
 license = "Apache-2.0"
 
 [dependencies]
-reqwest = "0.9.18"
+reqwest = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[dev-dependencies]
+tokio = { version = "0.2", features = ["macros"] }

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -48,9 +48,16 @@ fn main() -> Result<(), ZapApiError> {
         Err(e) => return Err(e),
     }
 
+    version(&service).await?;
+// Get the ZAP version
+async fn version(service: &ZapService) -> Result<(), ZapApiError> {
+    let res = zap_api::core::version(service).await?;
+    let zap_version = res["version"].to_string();
     println!("ZAP version : {}", zap_version);
 
-    // Start the ZAP (std) spider
+    Ok(())
+}
+
     println!("Starting the std spider");
     let res = zap_api::spider::scan(
         &service,

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -47,6 +47,9 @@ fn main() -> Result<(), ZapApiError> {
         Ok(v) => zap_version = v["version"].to_string(),
         Err(e) => return Err(e),
     }
+    // Include target url in scope
+    zap_api::context::new_context(&service, "api").await?;
+    zap_api::context::include_in_context(&service, "api", "http://localhost:3000/*").await?;
 
     version(&service).await?;
     spider(&service, &target_url).await?;

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -51,6 +51,7 @@ fn main() -> Result<(), ZapApiError> {
     version(&service).await?;
     spider(&service, &target_url).await?;
     scan(&service, &target_url).await?;
+    alerts(&service, &target_url).await?;
 // Get the ZAP version
 async fn version(service: &ZapService) -> Result<(), ZapApiError> {
     let res = zap_api::core::version(service).await?;
@@ -114,7 +115,30 @@ async fn scan(service: &ZapService, target_url: &str) -> Result<(), ZapApiError>
     Ok(())
 }
 
-    // TODO display alerts
+// Alerts
+async fn alerts(service: &ZapService, baseurl: &str) -> Result<(), ZapApiError> {
+    let res = zap_api::alert::alerts(service, baseurl, "", "", "").await?;
+    let alert_data: ZapAlerts = serde_json::from_value(res).unwrap();
+
+    println!("Number of alerts: {}", alert_data.alerts.len());
+    alert_data.alerts.into_iter().for_each(|alert| {
+        println!(
+            "ID: {}\tConfidence: {}\tAlert: {}",
+            alert.id, alert.confidence, alert.alert
+        )
+    });
 
     Ok(())
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct ZapAlerts {
+    alerts: Vec<Alerts>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct Alerts {
+    id: String,
+    alert: String,
+    confidence: String,
 }

--- a/src/acsrf.rs
+++ b/src/acsrf.rs
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 the ZAP development team
+ * Copyright 2020 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
  * limitations under the License.
  */
 
+
 use super::ZapApiError;
 use super::ZapService;
 use serde_json::Value;
 use std::collections::HashMap;
+
 
 /**
  * This file was automatically generated.
@@ -28,34 +30,35 @@ use std::collections::HashMap;
 /**
  * Lists the names of all anti-CSRF tokens
 */
-pub fn option_tokens_names(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_tokens_names(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "acsrf", "view", "optionTokensNames", params)
+    super::call(service, "acsrf", "view", "optionTokensNames", params).await
 }
 
 /**
  * Adds an anti-CSRF token with the given name, enabled by default
 */
-pub fn add_option_token(service: &ZapService, string: String) -> Result<Value, ZapApiError> {
+pub async fn add_option_token(service: &ZapService, string: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("String".to_string(), string);
-    super::call(service, "acsrf", "action", "addOptionToken", params)
+    params.insert("String".to_string(), string.to_string());
+    super::call(service, "acsrf", "action", "addOptionToken", params).await
 }
 
 /**
  * Removes the anti-CSRF token with the given name
 */
-pub fn remove_option_token(service: &ZapService, string: String) -> Result<Value, ZapApiError> {
+pub async fn remove_option_token(service: &ZapService, string: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("String".to_string(), string);
-    super::call(service, "acsrf", "action", "removeOptionToken", params)
+    params.insert("String".to_string(), string.to_string());
+    super::call(service, "acsrf", "action", "removeOptionToken", params).await
 }
 
 /**
  * Generate a form for testing lack of anti-CSRF tokens - typically invoked via ZAP
 */
-pub fn gen_form(service: &ZapService, hrefid: String) -> Result<Value, ZapApiError> {
+pub async fn gen_form(service: &ZapService, hrefid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("hrefId".to_string(), hrefid);
-    super::call(service, "acsrf", "other", "genForm", params)
+    params.insert("hrefId".to_string(), hrefid.to_string());
+    super::call(service, "acsrf", "other", "genForm", params).await
 }
+

--- a/src/ajax_spider.rs
+++ b/src/ajax_spider.rs
@@ -23,70 +23,71 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 /**
- * This file was automatically generated.
- */
-/**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn status(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn status(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ajaxSpider", "view", "status", params)
+    super::call(service, "ajaxSpider", "view", "status", params).await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn results(service: &ZapService, start: String, count: String) -> Result<Value, ZapApiError> {
+pub async fn results(
+    service: &ZapService,
+    start: String,
+    count: String,
+) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
     params.insert("start".to_string(), start);
     params.insert("count".to_string(), count);
-    super::call(service, "ajaxSpider", "view", "results", params)
+    super::call(service, "ajaxSpider", "view", "results", params).await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn number_of_results(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn number_of_results(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ajaxSpider", "view", "numberOfResults", params)
+    super::call(service, "ajaxSpider", "view", "numberOfResults", params).await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn full_results(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn full_results(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ajaxSpider", "view", "fullResults", params)
+    super::call(service, "ajaxSpider", "view", "fullResults", params).await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn option_browser_id(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_browser_id(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ajaxSpider", "view", "optionBrowserId", params)
+    super::call(service, "ajaxSpider", "view", "optionBrowserId", params).await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn option_event_wait(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_event_wait(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ajaxSpider", "view", "optionEventWait", params)
+    super::call(service, "ajaxSpider", "view", "optionEventWait", params).await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn option_max_crawl_depth(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_max_crawl_depth(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ajaxSpider", "view", "optionMaxCrawlDepth", params)
+    super::call(service, "ajaxSpider", "view", "optionMaxCrawlDepth", params).await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn option_max_crawl_states(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_max_crawl_states(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
     super::call(
         service,
@@ -95,20 +96,21 @@ pub fn option_max_crawl_states(service: &ZapService) -> Result<Value, ZapApiErro
         "optionMaxCrawlStates",
         params,
     )
+    .await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn option_max_duration(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_max_duration(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ajaxSpider", "view", "optionMaxDuration", params)
+    super::call(service, "ajaxSpider", "view", "optionMaxDuration", params).await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn option_number_of_browsers(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_number_of_browsers(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
     super::call(
         service,
@@ -117,20 +119,21 @@ pub fn option_number_of_browsers(service: &ZapService) -> Result<Value, ZapApiEr
         "optionNumberOfBrowsers",
         params,
     )
+    .await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn option_reload_wait(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_reload_wait(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ajaxSpider", "view", "optionReloadWait", params)
+    super::call(service, "ajaxSpider", "view", "optionReloadWait", params).await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn option_click_default_elems(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_click_default_elems(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
     super::call(
         service,
@@ -139,12 +142,13 @@ pub fn option_click_default_elems(service: &ZapService) -> Result<Value, ZapApiE
         "optionClickDefaultElems",
         params,
     )
+    .await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn option_click_elems_once(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_click_elems_once(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
     super::call(
         service,
@@ -153,14 +157,15 @@ pub fn option_click_elems_once(service: &ZapService) -> Result<Value, ZapApiErro
         "optionClickElemsOnce",
         params,
     )
+    .await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn option_random_inputs(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_random_inputs(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ajaxSpider", "view", "optionRandomInputs", params)
+    super::call(service, "ajaxSpider", "view", "optionRandomInputs", params).await
 }
 
 /**
@@ -168,7 +173,7 @@ pub fn option_random_inputs(service: &ZapService) -> Result<Value, ZapApiError> 
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn scan(
+pub async fn scan(
     service: &ZapService,
     url: String,
     inscope: String,
@@ -180,7 +185,7 @@ pub fn scan(
     params.insert("inScope".to_string(), inscope);
     params.insert("contextName".to_string(), contextname);
     params.insert("subtreeOnly".to_string(), subtreeonly);
-    super::call(service, "ajaxSpider", "action", "scan", params)
+    super::call(service, "ajaxSpider", "action", "scan", params).await
 }
 
 /**
@@ -188,7 +193,7 @@ pub fn scan(
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn scan_as_user(
+pub async fn scan_as_user(
     service: &ZapService,
     contextname: String,
     username: String,
@@ -200,21 +205,24 @@ pub fn scan_as_user(
     params.insert("userName".to_string(), username);
     params.insert("url".to_string(), url);
     params.insert("subtreeOnly".to_string(), subtreeonly);
-    super::call(service, "ajaxSpider", "action", "scanAsUser", params)
+    super::call(service, "ajaxSpider", "action", "scanAsUser", params).await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn stop(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn stop(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ajaxSpider", "action", "stop", params)
+    super::call(service, "ajaxSpider", "action", "stop", params).await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn set_option_browser_id(service: &ZapService, string: String) -> Result<Value, ZapApiError> {
+pub async fn set_option_browser_id(
+    service: &ZapService,
+    string: String,
+) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
     params.insert("String".to_string(), string);
     super::call(
@@ -224,12 +232,13 @@ pub fn set_option_browser_id(service: &ZapService, string: String) -> Result<Val
         "setOptionBrowserId",
         params,
     )
+    .await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn set_option_click_default_elems(
+pub async fn set_option_click_default_elems(
     service: &ZapService,
     boolean: String,
 ) -> Result<Value, ZapApiError> {
@@ -242,12 +251,13 @@ pub fn set_option_click_default_elems(
         "setOptionClickDefaultElems",
         params,
     )
+    .await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn set_option_click_elems_once(
+pub async fn set_option_click_elems_once(
     service: &ZapService,
     boolean: String,
 ) -> Result<Value, ZapApiError> {
@@ -260,12 +270,16 @@ pub fn set_option_click_elems_once(
         "setOptionClickElemsOnce",
         params,
     )
+    .await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn set_option_event_wait(service: &ZapService, integer: String) -> Result<Value, ZapApiError> {
+pub async fn set_option_event_wait(
+    service: &ZapService,
+    integer: String,
+) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
     params.insert("Integer".to_string(), integer);
     super::call(
@@ -275,12 +289,13 @@ pub fn set_option_event_wait(service: &ZapService, integer: String) -> Result<Va
         "setOptionEventWait",
         params,
     )
+    .await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn set_option_max_crawl_depth(
+pub async fn set_option_max_crawl_depth(
     service: &ZapService,
     integer: String,
 ) -> Result<Value, ZapApiError> {
@@ -293,12 +308,13 @@ pub fn set_option_max_crawl_depth(
         "setOptionMaxCrawlDepth",
         params,
     )
+    .await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn set_option_max_crawl_states(
+pub async fn set_option_max_crawl_states(
     service: &ZapService,
     integer: String,
 ) -> Result<Value, ZapApiError> {
@@ -311,12 +327,13 @@ pub fn set_option_max_crawl_states(
         "setOptionMaxCrawlStates",
         params,
     )
+    .await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn set_option_max_duration(
+pub async fn set_option_max_duration(
     service: &ZapService,
     integer: String,
 ) -> Result<Value, ZapApiError> {
@@ -329,12 +346,13 @@ pub fn set_option_max_duration(
         "setOptionMaxDuration",
         params,
     )
+    .await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn set_option_number_of_browsers(
+pub async fn set_option_number_of_browsers(
     service: &ZapService,
     integer: String,
 ) -> Result<Value, ZapApiError> {
@@ -347,12 +365,13 @@ pub fn set_option_number_of_browsers(
         "setOptionNumberOfBrowsers",
         params,
     )
+    .await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn set_option_random_inputs(
+pub async fn set_option_random_inputs(
     service: &ZapService,
     boolean: String,
 ) -> Result<Value, ZapApiError> {
@@ -365,12 +384,16 @@ pub fn set_option_random_inputs(
         "setOptionRandomInputs",
         params,
     )
+    .await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn set_option_reload_wait(service: &ZapService, integer: String) -> Result<Value, ZapApiError> {
+pub async fn set_option_reload_wait(
+    service: &ZapService,
+    integer: String,
+) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
     params.insert("Integer".to_string(), integer);
     super::call(
@@ -380,4 +403,5 @@ pub fn set_option_reload_wait(service: &ZapService, integer: String) -> Result<V
         "setOptionReloadWait",
         params,
     )
+    .await
 }

--- a/src/alert.rs
+++ b/src/alert.rs
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 the ZAP development team
+ * Copyright 2020 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
  * limitations under the License.
  */
 
+
 use super::ZapApiError;
 use super::ZapService;
 use serde_json::Value;
 use std::collections::HashMap;
+
 
 /**
  * This file was automatically generated.
@@ -28,94 +30,141 @@ use std::collections::HashMap;
 /**
  * Gets the alert with the given ID, the corresponding HTTP message can be obtained with the 'messageId' field and 'message' API method
 */
-pub fn alert(service: &ZapService, id: String) -> Result<Value, ZapApiError> {
+pub async fn alert(service: &ZapService, id: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("id".to_string(), id);
-    super::call(service, "alert", "view", "alert", params)
+    params.insert("id".to_string(), id.to_string());
+    super::call(service, "alert", "view", "alert", params).await
 }
 
 /**
  * Gets the alerts raised by ZAP, optionally filtering by URL or riskId, and paginating with 'start' position and 'count' of alerts
 */
-pub fn alerts(
-    service: &ZapService,
-    baseurl: String,
-    start: String,
-    count: String,
-    riskid: String,
-) -> Result<Value, ZapApiError> {
+pub async fn alerts(service: &ZapService, baseurl: &str, start: &str, count: &str, riskid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("baseurl".to_string(), baseurl);
-    params.insert("start".to_string(), start);
-    params.insert("count".to_string(), count);
-    params.insert("riskId".to_string(), riskid);
-    super::call(service, "alert", "view", "alerts", params)
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    params.insert("start".to_string(), start.to_string());
+    params.insert("count".to_string(), count.to_string());
+    params.insert("riskId".to_string(), riskid.to_string());
+    super::call(service, "alert", "view", "alerts", params).await
 }
 
 /**
  * Gets number of alerts grouped by each risk level, optionally filtering by URL
 */
-pub fn alerts_summary(service: &ZapService, baseurl: String) -> Result<Value, ZapApiError> {
+pub async fn alerts_summary(service: &ZapService, baseurl: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("baseurl".to_string(), baseurl);
-    super::call(service, "alert", "view", "alertsSummary", params)
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    super::call(service, "alert", "view", "alertsSummary", params).await
 }
 
 /**
  * Gets the number of alerts, optionally filtering by URL or riskId
 */
-pub fn number_of_alerts(
-    service: &ZapService,
-    baseurl: String,
-    riskid: String,
-) -> Result<Value, ZapApiError> {
+pub async fn number_of_alerts(service: &ZapService, baseurl: &str, riskid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("baseurl".to_string(), baseurl);
-    params.insert("riskId".to_string(), riskid);
-    super::call(service, "alert", "view", "numberOfAlerts", params)
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    params.insert("riskId".to_string(), riskid.to_string());
+    super::call(service, "alert", "view", "numberOfAlerts", params).await
 }
 
 /**
  * Gets a summary of the alerts, optionally filtered by a 'url'. If 'recurse' is true then all alerts that apply to urls that start with the specified 'url' will be returned, otherwise only those on exactly the same 'url' (ignoring url parameters)
 */
-pub fn alerts_by_risk(
-    service: &ZapService,
-    url: String,
-    recurse: String,
-) -> Result<Value, ZapApiError> {
+pub async fn alerts_by_risk(service: &ZapService, url: &str, recurse: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("url".to_string(), url);
-    params.insert("recurse".to_string(), recurse);
-    super::call(service, "alert", "view", "alertsByRisk", params)
+    params.insert("url".to_string(), url.to_string());
+    params.insert("recurse".to_string(), recurse.to_string());
+    super::call(service, "alert", "view", "alertsByRisk", params).await
 }
 
 /**
  * Gets a count of the alerts, optionally filtered as per alertsPerRisk
 */
-pub fn alert_counts_by_risk(
-    service: &ZapService,
-    url: String,
-    recurse: String,
-) -> Result<Value, ZapApiError> {
+pub async fn alert_counts_by_risk(service: &ZapService, url: &str, recurse: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("url".to_string(), url);
-    params.insert("recurse".to_string(), recurse);
-    super::call(service, "alert", "view", "alertCountsByRisk", params)
+    params.insert("url".to_string(), url.to_string());
+    params.insert("recurse".to_string(), recurse.to_string());
+    super::call(service, "alert", "view", "alertCountsByRisk", params).await
 }
 
 /**
  * Deletes all alerts of the current session.
 */
-pub fn delete_all_alerts(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn delete_all_alerts(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "alert", "action", "deleteAllAlerts", params)
+    super::call(service, "alert", "action", "deleteAllAlerts", params).await
 }
 
 /**
- * Deletes the alert with the given ID.
+ * Deletes the alert with the given ID. 
 */
-pub fn delete_alert(service: &ZapService, id: String) -> Result<Value, ZapApiError> {
+pub async fn delete_alert(service: &ZapService, id: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("id".to_string(), id);
-    super::call(service, "alert", "action", "deleteAlert", params)
+    params.insert("id".to_string(), id.to_string());
+    super::call(service, "alert", "action", "deleteAlert", params).await
 }
+
+/**
+ * Update the confidence of the alerts.
+*/
+pub async fn update_alerts_confidence(service: &ZapService, ids: &str, confidenceid: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("ids".to_string(), ids.to_string());
+    params.insert("confidenceId".to_string(), confidenceid.to_string());
+    super::call(service, "alert", "action", "updateAlertsConfidence", params).await
+}
+
+/**
+ * Update the risk of the alerts.
+*/
+pub async fn update_alerts_risk(service: &ZapService, ids: &str, riskid: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("ids".to_string(), ids.to_string());
+    params.insert("riskId".to_string(), riskid.to_string());
+    super::call(service, "alert", "action", "updateAlertsRisk", params).await
+}
+
+/**
+ * Update the alert with the given ID, with the provided details.
+*/
+#[allow(clippy::too_many_arguments)]
+pub async fn update_alert(service: &ZapService, id: &str, name: &str, riskid: &str, confidenceid: &str, description: &str, param: &str, attack: &str, otherinfo: &str, solution: &str, references: &str, evidence: &str, cweid: &str, wascid: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("id".to_string(), id.to_string());
+    params.insert("name".to_string(), name.to_string());
+    params.insert("riskId".to_string(), riskid.to_string());
+    params.insert("confidenceId".to_string(), confidenceid.to_string());
+    params.insert("description".to_string(), description.to_string());
+    params.insert("param".to_string(), param.to_string());
+    params.insert("attack".to_string(), attack.to_string());
+    params.insert("otherInfo".to_string(), otherinfo.to_string());
+    params.insert("solution".to_string(), solution.to_string());
+    params.insert("references".to_string(), references.to_string());
+    params.insert("evidence".to_string(), evidence.to_string());
+    params.insert("cweId".to_string(), cweid.to_string());
+    params.insert("wascId".to_string(), wascid.to_string());
+    super::call(service, "alert", "action", "updateAlert", params).await
+}
+
+/**
+ * Add an alert associated with the given message ID, with the provided details. (The ID of the created alert is returned.)
+*/
+#[allow(clippy::too_many_arguments)]
+pub async fn add_alert(service: &ZapService, messageid: &str, name: &str, riskid: &str, confidenceid: &str, description: &str, param: &str, attack: &str, otherinfo: &str, solution: &str, references: &str, evidence: &str, cweid: &str, wascid: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("messageId".to_string(), messageid.to_string());
+    params.insert("name".to_string(), name.to_string());
+    params.insert("riskId".to_string(), riskid.to_string());
+    params.insert("confidenceId".to_string(), confidenceid.to_string());
+    params.insert("description".to_string(), description.to_string());
+    params.insert("param".to_string(), param.to_string());
+    params.insert("attack".to_string(), attack.to_string());
+    params.insert("otherInfo".to_string(), otherinfo.to_string());
+    params.insert("solution".to_string(), solution.to_string());
+    params.insert("references".to_string(), references.to_string());
+    params.insert("evidence".to_string(), evidence.to_string());
+    params.insert("cweId".to_string(), cweid.to_string());
+    params.insert("wascId".to_string(), wascid.to_string());
+    super::call(service, "alert", "action", "addAlert", params).await
+}
+

--- a/src/alert_filter.rs
+++ b/src/alert_filter.rs
@@ -23,17 +23,17 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 /**
- * This file was automatically generated.
- */
-/**
  * Lists the alert filters of the context with the given ID.
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn alert_filter_list(service: &ZapService, contextid: String) -> Result<Value, ZapApiError> {
+pub async fn alert_filter_list(
+    service: &ZapService,
+    contextid: String,
+) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
     params.insert("contextId".to_string(), contextid);
-    super::call(service, "alertFilter", "view", "alertFilterList", params)
+    super::call(service, "alertFilter", "view", "alertFilterList", params).await
 }
 
 /**
@@ -42,7 +42,7 @@ pub fn alert_filter_list(service: &ZapService, contextid: String) -> Result<Valu
  * This component is optional and therefore the API will only work if it is installed
 */
 #[allow(clippy::too_many_arguments)]
-pub fn add_alert_filter(
+pub async fn add_alert_filter(
     service: &ZapService,
     contextid: String,
     ruleid: String,
@@ -60,7 +60,7 @@ pub fn add_alert_filter(
     params.insert("urlIsRegex".to_string(), urlisregex);
     params.insert("parameter".to_string(), parameter);
     params.insert("enabled".to_string(), enabled);
-    super::call(service, "alertFilter", "action", "addAlertFilter", params)
+    super::call(service, "alertFilter", "action", "addAlertFilter", params).await
 }
 
 /**
@@ -69,7 +69,7 @@ pub fn add_alert_filter(
  * This component is optional and therefore the API will only work if it is installed
 */
 #[allow(clippy::too_many_arguments)]
-pub fn remove_alert_filter(
+pub async fn remove_alert_filter(
     service: &ZapService,
     contextid: String,
     ruleid: String,
@@ -94,4 +94,5 @@ pub fn remove_alert_filter(
         "removeAlertFilter",
         params,
     )
+    .await
 }

--- a/src/ascan.rs
+++ b/src/ascan.rs
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 the ZAP development team
+ * Copyright 2020 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,905 +17,774 @@
  * limitations under the License.
  */
 
+
 use super::ZapApiError;
 use super::ZapService;
 use serde_json::Value;
 use std::collections::HashMap;
 
+
 /**
  * This file was automatically generated.
  */
-pub fn status(service: &ZapService, scanid: String) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn status(service: &ZapService, scanid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanId".to_string(), scanid);
-    super::call(service, "ascan", "view", "status", params)
+    params.insert("scanId".to_string(), scanid.to_string());
+    super::call(service, "ascan", "view", "status", params).await
 }
 
-pub fn scan_progress(service: &ZapService, scanid: String) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn scan_progress(service: &ZapService, scanid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanId".to_string(), scanid);
-    super::call(service, "ascan", "view", "scanProgress", params)
+    params.insert("scanId".to_string(), scanid.to_string());
+    super::call(service, "ascan", "view", "scanProgress", params).await
 }
 
 /**
  * Gets the IDs of the messages sent during the scan with the given ID. A message can be obtained with 'message' core view.
 */
-pub fn messages_ids(service: &ZapService, scanid: String) -> Result<Value, ZapApiError> {
+pub async fn messages_ids(service: &ZapService, scanid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanId".to_string(), scanid);
-    super::call(service, "ascan", "view", "messagesIds", params)
+    params.insert("scanId".to_string(), scanid.to_string());
+    super::call(service, "ascan", "view", "messagesIds", params).await
 }
 
 /**
  * Gets the IDs of the alerts raised during the scan with the given ID. An alert can be obtained with 'alert' core view.
 */
-pub fn alerts_ids(service: &ZapService, scanid: String) -> Result<Value, ZapApiError> {
+pub async fn alerts_ids(service: &ZapService, scanid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanId".to_string(), scanid);
-    super::call(service, "ascan", "view", "alertsIds", params)
+    params.insert("scanId".to_string(), scanid.to_string());
+    super::call(service, "ascan", "view", "alertsIds", params).await
 }
 
-pub fn scans(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn scans(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "view", "scans", params)
+    super::call(service, "ascan", "view", "scans", params).await
 }
 
-pub fn scan_policy_names(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn scan_policy_names(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "view", "scanPolicyNames", params)
+    super::call(service, "ascan", "view", "scanPolicyNames", params).await
 }
 
 /**
  * Gets the regexes of URLs excluded from the active scans.
 */
-pub fn excluded_from_scan(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn excluded_from_scan(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "view", "excludedFromScan", params)
+    super::call(service, "ascan", "view", "excludedFromScan", params).await
 }
 
 /**
  * Gets the scanners, optionally, of the given scan policy and/or scanner policy/category ID.
 */
-pub fn scanners(
-    service: &ZapService,
-    scanpolicyname: String,
-    policyid: String,
-) -> Result<Value, ZapApiError> {
+pub async fn scanners(service: &ZapService, scanpolicyname: &str, policyid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanPolicyName".to_string(), scanpolicyname);
-    params.insert("policyId".to_string(), policyid);
-    super::call(service, "ascan", "view", "scanners", params)
+    params.insert("scanPolicyName".to_string(), scanpolicyname.to_string());
+    params.insert("policyId".to_string(), policyid.to_string());
+    super::call(service, "ascan", "view", "scanners", params).await
 }
 
-pub fn policies(
-    service: &ZapService,
-    scanpolicyname: String,
-    policyid: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn policies(service: &ZapService, scanpolicyname: &str, policyid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanPolicyName".to_string(), scanpolicyname);
-    params.insert("policyId".to_string(), policyid);
-    super::call(service, "ascan", "view", "policies", params)
+    params.insert("scanPolicyName".to_string(), scanpolicyname.to_string());
+    params.insert("policyId".to_string(), policyid.to_string());
+    super::call(service, "ascan", "view", "policies", params).await
 }
 
-pub fn attack_mode_queue(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn attack_mode_queue(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "view", "attackModeQueue", params)
+    super::call(service, "ascan", "view", "attackModeQueue", params).await
 }
 
 /**
  * Gets all the parameters that are excluded. For each parameter the following are shown: the name, the URL, and the parameter type.
 */
-pub fn excluded_params(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn excluded_params(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "view", "excludedParams", params)
+    super::call(service, "ascan", "view", "excludedParams", params).await
 }
 
 /**
  * Use view excludedParams instead.
- * Deprecated
 */
-pub fn option_excluded_param_list(service: &ZapService) -> Result<Value, ZapApiError> {
+#[deprecated]
+pub async fn option_excluded_param_list(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "view", "optionExcludedParamList", params)
+    super::call(service, "ascan", "view", "optionExcludedParamList", params).await
 }
 
 /**
  * Gets all the types of excluded parameters. For each type the following are shown: the ID and the name.
 */
-pub fn excluded_param_types(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn excluded_param_types(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "view", "excludedParamTypes", params)
+    super::call(service, "ascan", "view", "excludedParamTypes", params).await
 }
 
-pub fn option_attack_policy(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_attack_policy(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "view", "optionAttackPolicy", params)
+    super::call(service, "ascan", "view", "optionAttackPolicy", params).await
 }
 
-pub fn option_default_policy(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_default_policy(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "view", "optionDefaultPolicy", params)
+    super::call(service, "ascan", "view", "optionDefaultPolicy", params).await
 }
 
-pub fn option_delay_in_ms(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_delay_in_ms(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "view", "optionDelayInMs", params)
+    super::call(service, "ascan", "view", "optionDelayInMs", params).await
 }
 
-pub fn option_handle_anti_csrf_tokens(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_handle_anti_csrf_tokens(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "ascan",
-        "view",
-        "optionHandleAntiCSRFTokens",
-        params,
-    )
+    super::call(service, "ascan", "view", "optionHandleAntiCSRFTokens", params).await
 }
 
-pub fn option_host_per_scan(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_host_per_scan(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "view", "optionHostPerScan", params)
+    super::call(service, "ascan", "view", "optionHostPerScan", params).await
 }
 
-pub fn option_max_chart_time_in_mins(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_max_chart_time_in_mins(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "view", "optionMaxChartTimeInMins", params)
+    super::call(service, "ascan", "view", "optionMaxChartTimeInMins", params).await
 }
 
-pub fn option_max_results_to_list(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_max_results_to_list(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "view", "optionMaxResultsToList", params)
+    super::call(service, "ascan", "view", "optionMaxResultsToList", params).await
 }
 
-pub fn option_max_rule_duration_in_mins(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_max_rule_duration_in_mins(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "ascan",
-        "view",
-        "optionMaxRuleDurationInMins",
-        params,
-    )
+    super::call(service, "ascan", "view", "optionMaxRuleDurationInMins", params).await
 }
 
-pub fn option_max_scan_duration_in_mins(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_max_scan_duration_in_mins(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "ascan",
-        "view",
-        "optionMaxScanDurationInMins",
-        params,
-    )
+    super::call(service, "ascan", "view", "optionMaxScanDurationInMins", params).await
 }
 
-pub fn option_max_scans_in_ui(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_max_scans_in_ui(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "view", "optionMaxScansInUI", params)
+    super::call(service, "ascan", "view", "optionMaxScansInUI", params).await
 }
 
-pub fn option_target_params_enabled_rpc(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_target_params_enabled_rpc(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "ascan",
-        "view",
-        "optionTargetParamsEnabledRPC",
-        params,
-    )
+    super::call(service, "ascan", "view", "optionTargetParamsEnabledRPC", params).await
 }
 
-pub fn option_target_params_injectable(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_target_params_injectable(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "ascan",
-        "view",
-        "optionTargetParamsInjectable",
-        params,
-    )
+    super::call(service, "ascan", "view", "optionTargetParamsInjectable", params).await
 }
 
-pub fn option_thread_per_host(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_thread_per_host(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "view", "optionThreadPerHost", params)
+    super::call(service, "ascan", "view", "optionThreadPerHost", params).await
 }
 
 /**
  * Tells whether or not the active scanner should add a query parameter to GET request that don't have parameters to start with.
 */
-pub fn option_add_query_param(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_add_query_param(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "view", "optionAddQueryParam", params)
+    super::call(service, "ascan", "view", "optionAddQueryParam", params).await
 }
 
-pub fn option_allow_attack_on_start(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_allow_attack_on_start(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "view", "optionAllowAttackOnStart", params)
+    super::call(service, "ascan", "view", "optionAllowAttackOnStart", params).await
 }
 
 /**
  * Tells whether or not the active scanner should inject the HTTP request header X-ZAP-Scan-ID, with the ID of the scanner that's sending the requests.
 */
-pub fn option_inject_plugin_id_in_header(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_inject_plugin_id_in_header(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "ascan",
-        "view",
-        "optionInjectPluginIdInHeader",
-        params,
-    )
+    super::call(service, "ascan", "view", "optionInjectPluginIdInHeader", params).await
 }
 
-pub fn option_prompt_in_attack_mode(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_prompt_in_attack_mode(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "view", "optionPromptInAttackMode", params)
+    super::call(service, "ascan", "view", "optionPromptInAttackMode", params).await
 }
 
-pub fn option_prompt_to_clear_finished_scans(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_prompt_to_clear_finished_scans(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "ascan",
-        "view",
-        "optionPromptToClearFinishedScans",
-        params,
-    )
+    super::call(service, "ascan", "view", "optionPromptToClearFinishedScans", params).await
 }
 
-pub fn option_rescan_in_attack_mode(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_rescan_in_attack_mode(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "view", "optionRescanInAttackMode", params)
+    super::call(service, "ascan", "view", "optionRescanInAttackMode", params).await
 }
 
 /**
  * Tells whether or not the HTTP Headers of all requests should be scanned. Not just requests that send parameters, through the query or request body.
 */
-pub fn option_scan_headers_all_requests(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_scan_headers_all_requests(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "ascan",
-        "view",
-        "optionScanHeadersAllRequests",
-        params,
-    )
+    super::call(service, "ascan", "view", "optionScanHeadersAllRequests", params).await
 }
 
-pub fn option_show_advanced_dialog(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_show_advanced_dialog(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "view", "optionShowAdvancedDialog", params)
+    super::call(service, "ascan", "view", "optionShowAdvancedDialog", params).await
 }
 
 /**
  * Runs the active scanner against the given URL and/or Context. Optionally, the 'recurse' parameter can be used to scan URLs under the given URL, the parameter 'inScopeOnly' can be used to constrain the scan to URLs that are in scope (ignored if a Context is specified), the parameter 'scanPolicyName' allows to specify the scan policy (if none is given it uses the default scan policy), the parameters 'method' and 'postData' allow to select a given request in conjunction with the given URL.
 */
 #[allow(clippy::too_many_arguments)]
-pub fn scan(
-    service: &ZapService,
-    url: String,
-    recurse: String,
-    inscopeonly: String,
-    scanpolicyname: String,
-    method: String,
-    postdata: String,
-    contextid: String,
-) -> Result<Value, ZapApiError> {
+pub async fn scan(service: &ZapService, url: &str, recurse: &str, inscopeonly: &str, scanpolicyname: &str, method: &str, postdata: &str, contextid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("url".to_string(), url);
-    params.insert("recurse".to_string(), recurse);
-    params.insert("inScopeOnly".to_string(), inscopeonly);
-    params.insert("scanPolicyName".to_string(), scanpolicyname);
-    params.insert("method".to_string(), method);
-    params.insert("postData".to_string(), postdata);
-    params.insert("contextId".to_string(), contextid);
-    super::call(service, "ascan", "action", "scan", params)
+    params.insert("url".to_string(), url.to_string());
+    params.insert("recurse".to_string(), recurse.to_string());
+    params.insert("inScopeOnly".to_string(), inscopeonly.to_string());
+    params.insert("scanPolicyName".to_string(), scanpolicyname.to_string());
+    params.insert("method".to_string(), method.to_string());
+    params.insert("postData".to_string(), postdata.to_string());
+    params.insert("contextId".to_string(), contextid.to_string());
+    super::call(service, "ascan", "action", "scan", params).await
 }
 
 /**
  * Active Scans from the perspective of a User, obtained using the given Context ID and User ID. See 'scan' action for more details.
 */
 #[allow(clippy::too_many_arguments)]
-pub fn scan_as_user(
-    service: &ZapService,
-    url: String,
-    contextid: String,
-    userid: String,
-    recurse: String,
-    scanpolicyname: String,
-    method: String,
-    postdata: String,
-) -> Result<Value, ZapApiError> {
+pub async fn scan_as_user(service: &ZapService, url: &str, contextid: &str, userid: &str, recurse: &str, scanpolicyname: &str, method: &str, postdata: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("url".to_string(), url);
-    params.insert("contextId".to_string(), contextid);
-    params.insert("userId".to_string(), userid);
-    params.insert("recurse".to_string(), recurse);
-    params.insert("scanPolicyName".to_string(), scanpolicyname);
-    params.insert("method".to_string(), method);
-    params.insert("postData".to_string(), postdata);
-    super::call(service, "ascan", "action", "scanAsUser", params)
+    params.insert("url".to_string(), url.to_string());
+    params.insert("contextId".to_string(), contextid.to_string());
+    params.insert("userId".to_string(), userid.to_string());
+    params.insert("recurse".to_string(), recurse.to_string());
+    params.insert("scanPolicyName".to_string(), scanpolicyname.to_string());
+    params.insert("method".to_string(), method.to_string());
+    params.insert("postData".to_string(), postdata.to_string());
+    super::call(service, "ascan", "action", "scanAsUser", params).await
 }
 
-pub fn pause(service: &ZapService, scanid: String) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn pause(service: &ZapService, scanid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanId".to_string(), scanid);
-    super::call(service, "ascan", "action", "pause", params)
+    params.insert("scanId".to_string(), scanid.to_string());
+    super::call(service, "ascan", "action", "pause", params).await
 }
 
-pub fn resume(service: &ZapService, scanid: String) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn resume(service: &ZapService, scanid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanId".to_string(), scanid);
-    super::call(service, "ascan", "action", "resume", params)
+    params.insert("scanId".to_string(), scanid.to_string());
+    super::call(service, "ascan", "action", "resume", params).await
 }
 
-pub fn stop(service: &ZapService, scanid: String) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn stop(service: &ZapService, scanid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanId".to_string(), scanid);
-    super::call(service, "ascan", "action", "stop", params)
+    params.insert("scanId".to_string(), scanid.to_string());
+    super::call(service, "ascan", "action", "stop", params).await
 }
 
-pub fn remove_scan(service: &ZapService, scanid: String) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn remove_scan(service: &ZapService, scanid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanId".to_string(), scanid);
-    super::call(service, "ascan", "action", "removeScan", params)
+    params.insert("scanId".to_string(), scanid.to_string());
+    super::call(service, "ascan", "action", "removeScan", params).await
 }
 
-pub fn pause_all_scans(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn pause_all_scans(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "action", "pauseAllScans", params)
+    super::call(service, "ascan", "action", "pauseAllScans", params).await
 }
 
-pub fn resume_all_scans(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn resume_all_scans(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "action", "resumeAllScans", params)
+    super::call(service, "ascan", "action", "resumeAllScans", params).await
 }
 
-pub fn stop_all_scans(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn stop_all_scans(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "action", "stopAllScans", params)
+    super::call(service, "ascan", "action", "stopAllScans", params).await
 }
 
-pub fn remove_all_scans(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn remove_all_scans(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "action", "removeAllScans", params)
+    super::call(service, "ascan", "action", "removeAllScans", params).await
 }
 
 /**
  * Clears the regexes of URLs excluded from the active scans.
 */
-pub fn clear_excluded_from_scan(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn clear_excluded_from_scan(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "ascan", "action", "clearExcludedFromScan", params)
+    super::call(service, "ascan", "action", "clearExcludedFromScan", params).await
 }
 
 /**
  * Adds a regex of URLs that should be excluded from the active scans.
 */
-pub fn exclude_from_scan(service: &ZapService, regex: String) -> Result<Value, ZapApiError> {
+pub async fn exclude_from_scan(service: &ZapService, regex: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("regex".to_string(), regex);
-    super::call(service, "ascan", "action", "excludeFromScan", params)
+    params.insert("regex".to_string(), regex.to_string());
+    super::call(service, "ascan", "action", "excludeFromScan", params).await
 }
 
 /**
  * Enables all scanners of the scan policy with the given name, or the default if none given.
 */
-pub fn enable_all_scanners(
-    service: &ZapService,
-    scanpolicyname: String,
-) -> Result<Value, ZapApiError> {
+pub async fn enable_all_scanners(service: &ZapService, scanpolicyname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanPolicyName".to_string(), scanpolicyname);
-    super::call(service, "ascan", "action", "enableAllScanners", params)
+    params.insert("scanPolicyName".to_string(), scanpolicyname.to_string());
+    super::call(service, "ascan", "action", "enableAllScanners", params).await
 }
 
 /**
  * Disables all scanners of the scan policy with the given name, or the default if none given.
 */
-pub fn disable_all_scanners(
-    service: &ZapService,
-    scanpolicyname: String,
-) -> Result<Value, ZapApiError> {
+pub async fn disable_all_scanners(service: &ZapService, scanpolicyname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanPolicyName".to_string(), scanpolicyname);
-    super::call(service, "ascan", "action", "disableAllScanners", params)
+    params.insert("scanPolicyName".to_string(), scanpolicyname.to_string());
+    super::call(service, "ascan", "action", "disableAllScanners", params).await
 }
 
 /**
  * Enables the scanners with the given IDs (comma separated list of IDs) of the scan policy with the given name, or the default if none given.
 */
-pub fn enable_scanners(
-    service: &ZapService,
-    ids: String,
-    scanpolicyname: String,
-) -> Result<Value, ZapApiError> {
+pub async fn enable_scanners(service: &ZapService, ids: &str, scanpolicyname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("ids".to_string(), ids);
-    params.insert("scanPolicyName".to_string(), scanpolicyname);
-    super::call(service, "ascan", "action", "enableScanners", params)
+    params.insert("ids".to_string(), ids.to_string());
+    params.insert("scanPolicyName".to_string(), scanpolicyname.to_string());
+    super::call(service, "ascan", "action", "enableScanners", params).await
 }
 
 /**
  * Disables the scanners with the given IDs (comma separated list of IDs) of the scan policy with the given name, or the default if none given.
 */
-pub fn disable_scanners(
-    service: &ZapService,
-    ids: String,
-    scanpolicyname: String,
-) -> Result<Value, ZapApiError> {
+pub async fn disable_scanners(service: &ZapService, ids: &str, scanpolicyname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("ids".to_string(), ids);
-    params.insert("scanPolicyName".to_string(), scanpolicyname);
-    super::call(service, "ascan", "action", "disableScanners", params)
+    params.insert("ids".to_string(), ids.to_string());
+    params.insert("scanPolicyName".to_string(), scanpolicyname.to_string());
+    super::call(service, "ascan", "action", "disableScanners", params).await
 }
 
-pub fn set_enabled_policies(
-    service: &ZapService,
-    ids: String,
-    scanpolicyname: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_enabled_policies(service: &ZapService, ids: &str, scanpolicyname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("ids".to_string(), ids);
-    params.insert("scanPolicyName".to_string(), scanpolicyname);
-    super::call(service, "ascan", "action", "setEnabledPolicies", params)
+    params.insert("ids".to_string(), ids.to_string());
+    params.insert("scanPolicyName".to_string(), scanpolicyname.to_string());
+    super::call(service, "ascan", "action", "setEnabledPolicies", params).await
 }
 
-pub fn set_policy_attack_strength(
-    service: &ZapService,
-    id: String,
-    attackstrength: String,
-    scanpolicyname: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_policy_attack_strength(service: &ZapService, id: &str, attackstrength: &str, scanpolicyname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("id".to_string(), id);
-    params.insert("attackStrength".to_string(), attackstrength);
-    params.insert("scanPolicyName".to_string(), scanpolicyname);
-    super::call(
-        service,
-        "ascan",
-        "action",
-        "setPolicyAttackStrength",
-        params,
-    )
+    params.insert("id".to_string(), id.to_string());
+    params.insert("attackStrength".to_string(), attackstrength.to_string());
+    params.insert("scanPolicyName".to_string(), scanpolicyname.to_string());
+    super::call(service, "ascan", "action", "setPolicyAttackStrength", params).await
 }
 
-pub fn set_policy_alert_threshold(
-    service: &ZapService,
-    id: String,
-    alertthreshold: String,
-    scanpolicyname: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_policy_alert_threshold(service: &ZapService, id: &str, alertthreshold: &str, scanpolicyname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("id".to_string(), id);
-    params.insert("alertThreshold".to_string(), alertthreshold);
-    params.insert("scanPolicyName".to_string(), scanpolicyname);
-    super::call(
-        service,
-        "ascan",
-        "action",
-        "setPolicyAlertThreshold",
-        params,
-    )
+    params.insert("id".to_string(), id.to_string());
+    params.insert("alertThreshold".to_string(), alertthreshold.to_string());
+    params.insert("scanPolicyName".to_string(), scanpolicyname.to_string());
+    super::call(service, "ascan", "action", "setPolicyAlertThreshold", params).await
 }
 
-pub fn set_scanner_attack_strength(
-    service: &ZapService,
-    id: String,
-    attackstrength: String,
-    scanpolicyname: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_scanner_attack_strength(service: &ZapService, id: &str, attackstrength: &str, scanpolicyname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("id".to_string(), id);
-    params.insert("attackStrength".to_string(), attackstrength);
-    params.insert("scanPolicyName".to_string(), scanpolicyname);
-    super::call(
-        service,
-        "ascan",
-        "action",
-        "setScannerAttackStrength",
-        params,
-    )
+    params.insert("id".to_string(), id.to_string());
+    params.insert("attackStrength".to_string(), attackstrength.to_string());
+    params.insert("scanPolicyName".to_string(), scanpolicyname.to_string());
+    super::call(service, "ascan", "action", "setScannerAttackStrength", params).await
 }
 
-pub fn set_scanner_alert_threshold(
-    service: &ZapService,
-    id: String,
-    alertthreshold: String,
-    scanpolicyname: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_scanner_alert_threshold(service: &ZapService, id: &str, alertthreshold: &str, scanpolicyname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("id".to_string(), id);
-    params.insert("alertThreshold".to_string(), alertthreshold);
-    params.insert("scanPolicyName".to_string(), scanpolicyname);
-    super::call(
-        service,
-        "ascan",
-        "action",
-        "setScannerAlertThreshold",
-        params,
-    )
+    params.insert("id".to_string(), id.to_string());
+    params.insert("alertThreshold".to_string(), alertthreshold.to_string());
+    params.insert("scanPolicyName".to_string(), scanpolicyname.to_string());
+    super::call(service, "ascan", "action", "setScannerAlertThreshold", params).await
 }
 
-pub fn add_scan_policy(
-    service: &ZapService,
-    scanpolicyname: String,
-    alertthreshold: String,
-    attackstrength: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn add_scan_policy(service: &ZapService, scanpolicyname: &str, alertthreshold: &str, attackstrength: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanPolicyName".to_string(), scanpolicyname);
-    params.insert("alertThreshold".to_string(), alertthreshold);
-    params.insert("attackStrength".to_string(), attackstrength);
-    super::call(service, "ascan", "action", "addScanPolicy", params)
+    params.insert("scanPolicyName".to_string(), scanpolicyname.to_string());
+    params.insert("alertThreshold".to_string(), alertthreshold.to_string());
+    params.insert("attackStrength".to_string(), attackstrength.to_string());
+    super::call(service, "ascan", "action", "addScanPolicy", params).await
 }
 
-pub fn remove_scan_policy(
-    service: &ZapService,
-    scanpolicyname: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn remove_scan_policy(service: &ZapService, scanpolicyname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanPolicyName".to_string(), scanpolicyname);
-    super::call(service, "ascan", "action", "removeScanPolicy", params)
+    params.insert("scanPolicyName".to_string(), scanpolicyname.to_string());
+    super::call(service, "ascan", "action", "removeScanPolicy", params).await
 }
 
-pub fn update_scan_policy(
-    service: &ZapService,
-    scanpolicyname: String,
-    alertthreshold: String,
-    attackstrength: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn update_scan_policy(service: &ZapService, scanpolicyname: &str, alertthreshold: &str, attackstrength: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanPolicyName".to_string(), scanpolicyname);
-    params.insert("alertThreshold".to_string(), alertthreshold);
-    params.insert("attackStrength".to_string(), attackstrength);
-    super::call(service, "ascan", "action", "updateScanPolicy", params)
+    params.insert("scanPolicyName".to_string(), scanpolicyname.to_string());
+    params.insert("alertThreshold".to_string(), alertthreshold.to_string());
+    params.insert("attackStrength".to_string(), attackstrength.to_string());
+    super::call(service, "ascan", "action", "updateScanPolicy", params).await
 }
 
 /**
  * Imports a Scan Policy using the given file system path.
 */
-pub fn import_scan_policy(service: &ZapService, path: String) -> Result<Value, ZapApiError> {
+pub async fn import_scan_policy(service: &ZapService, path: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("path".to_string(), path);
-    super::call(service, "ascan", "action", "importScanPolicy", params)
+    params.insert("path".to_string(), path.to_string());
+    super::call(service, "ascan", "action", "importScanPolicy", params).await
 }
 
 /**
- * Adds a new parameter excluded from the scan, using the specified name. Optionally sets if the new entry applies to a specific URL (default, all URLs) and sets the ID of the type of the parameter (default, ID of any type). The type IDs can be obtained with the view excludedParamTypes.
+ * Adds a new parameter excluded from the scan, using the specified name. Optionally sets if the new entry applies to a specific URL (default, all URLs) and sets the ID of the type of the parameter (default, ID of any type). The type IDs can be obtained with the view excludedParamTypes. 
 */
-pub fn add_excluded_param(
-    service: &ZapService,
-    name: String,
-    typ: String,
-    url: String,
-) -> Result<Value, ZapApiError> {
+pub async fn add_excluded_param(service: &ZapService, name: &str, typ: &str, url: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("name".to_string(), name);
-    params.insert("type".to_string(), typ);
-    params.insert("url".to_string(), url);
-    super::call(service, "ascan", "action", "addExcludedParam", params)
+    params.insert("name".to_string(), name.to_string());
+    params.insert("type".to_string(), typ.to_string());
+    params.insert("url".to_string(), url.to_string());
+    super::call(service, "ascan", "action", "addExcludedParam", params).await
 }
 
 /**
  * Modifies a parameter excluded from the scan. Allows to modify the name, the URL and the type of parameter. The parameter is selected with its index, which can be obtained with the view excludedParams.
 */
-pub fn modify_excluded_param(
-    service: &ZapService,
-    idx: String,
-    name: String,
-    typ: String,
-    url: String,
-) -> Result<Value, ZapApiError> {
+pub async fn modify_excluded_param(service: &ZapService, idx: &str, name: &str, typ: &str, url: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("idx".to_string(), idx);
-    params.insert("name".to_string(), name);
-    params.insert("type".to_string(), typ);
-    params.insert("url".to_string(), url);
-    super::call(service, "ascan", "action", "modifyExcludedParam", params)
+    params.insert("idx".to_string(), idx.to_string());
+    params.insert("name".to_string(), name.to_string());
+    params.insert("type".to_string(), typ.to_string());
+    params.insert("url".to_string(), url.to_string());
+    super::call(service, "ascan", "action", "modifyExcludedParam", params).await
 }
 
 /**
  * Removes a parameter excluded from the scan, with the given index. The index can be obtained with the view excludedParams.
 */
-pub fn remove_excluded_param(service: &ZapService, idx: String) -> Result<Value, ZapApiError> {
+pub async fn remove_excluded_param(service: &ZapService, idx: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("idx".to_string(), idx);
-    super::call(service, "ascan", "action", "removeExcludedParam", params)
+    params.insert("idx".to_string(), idx.to_string());
+    super::call(service, "ascan", "action", "removeExcludedParam", params).await
 }
 
 /**
  * Skips the scanner using the given IDs of the scan and the scanner.
 */
-pub fn skip_scanner(
-    service: &ZapService,
-    scanid: String,
-    scannerid: String,
-) -> Result<Value, ZapApiError> {
+pub async fn skip_scanner(service: &ZapService, scanid: &str, scannerid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanId".to_string(), scanid);
-    params.insert("scannerId".to_string(), scannerid);
-    super::call(service, "ascan", "action", "skipScanner", params)
+    params.insert("scanId".to_string(), scanid.to_string());
+    params.insert("scannerId".to_string(), scannerid.to_string());
+    super::call(service, "ascan", "action", "skipScanner", params).await
 }
 
-pub fn set_option_attack_policy(
-    service: &ZapService,
-    string: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_attack_policy(service: &ZapService, string: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("String".to_string(), string);
-    super::call(service, "ascan", "action", "setOptionAttackPolicy", params)
+    params.insert("String".to_string(), string.to_string());
+    super::call(service, "ascan", "action", "setOptionAttackPolicy", params).await
 }
 
-pub fn set_option_default_policy(
-    service: &ZapService,
-    string: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_default_policy(service: &ZapService, string: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("String".to_string(), string);
-    super::call(service, "ascan", "action", "setOptionDefaultPolicy", params)
+    params.insert("String".to_string(), string.to_string());
+    super::call(service, "ascan", "action", "setOptionDefaultPolicy", params).await
 }
 
 /**
  * Sets whether or not the active scanner should add a query param to GET requests which do not have parameters to start with.
 */
-pub fn set_option_add_query_param(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_option_add_query_param(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(service, "ascan", "action", "setOptionAddQueryParam", params)
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "ascan", "action", "setOptionAddQueryParam", params).await
 }
 
-pub fn set_option_allow_attack_on_start(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_allow_attack_on_start(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "ascan",
-        "action",
-        "setOptionAllowAttackOnStart",
-        params,
-    )
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "ascan", "action", "setOptionAllowAttackOnStart", params).await
 }
 
-pub fn set_option_delay_in_ms(service: &ZapService, integer: String) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_delay_in_ms(service: &ZapService, integer: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Integer".to_string(), integer);
-    super::call(service, "ascan", "action", "setOptionDelayInMs", params)
+    params.insert("Integer".to_string(), integer.to_string());
+    super::call(service, "ascan", "action", "setOptionDelayInMs", params).await
 }
 
-pub fn set_option_handle_anti_csrf_tokens(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_handle_anti_csrf_tokens(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "ascan",
-        "action",
-        "setOptionHandleAntiCSRFTokens",
-        params,
-    )
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "ascan", "action", "setOptionHandleAntiCSRFTokens", params).await
 }
 
-pub fn set_option_host_per_scan(
-    service: &ZapService,
-    integer: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_host_per_scan(service: &ZapService, integer: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Integer".to_string(), integer);
-    super::call(service, "ascan", "action", "setOptionHostPerScan", params)
+    params.insert("Integer".to_string(), integer.to_string());
+    super::call(service, "ascan", "action", "setOptionHostPerScan", params).await
 }
 
 /**
  * Sets whether or not the active scanner should inject the HTTP request header X-ZAP-Scan-ID, with the ID of the scanner that's sending the requests.
 */
-pub fn set_option_inject_plugin_id_in_header(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_option_inject_plugin_id_in_header(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "ascan",
-        "action",
-        "setOptionInjectPluginIdInHeader",
-        params,
-    )
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "ascan", "action", "setOptionInjectPluginIdInHeader", params).await
 }
 
-pub fn set_option_max_chart_time_in_mins(
-    service: &ZapService,
-    integer: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_max_chart_time_in_mins(service: &ZapService, integer: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Integer".to_string(), integer);
-    super::call(
-        service,
-        "ascan",
-        "action",
-        "setOptionMaxChartTimeInMins",
-        params,
-    )
+    params.insert("Integer".to_string(), integer.to_string());
+    super::call(service, "ascan", "action", "setOptionMaxChartTimeInMins", params).await
 }
 
-pub fn set_option_max_results_to_list(
-    service: &ZapService,
-    integer: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_max_results_to_list(service: &ZapService, integer: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Integer".to_string(), integer);
-    super::call(
-        service,
-        "ascan",
-        "action",
-        "setOptionMaxResultsToList",
-        params,
-    )
+    params.insert("Integer".to_string(), integer.to_string());
+    super::call(service, "ascan", "action", "setOptionMaxResultsToList", params).await
 }
 
-pub fn set_option_max_rule_duration_in_mins(
-    service: &ZapService,
-    integer: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_max_rule_duration_in_mins(service: &ZapService, integer: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Integer".to_string(), integer);
-    super::call(
-        service,
-        "ascan",
-        "action",
-        "setOptionMaxRuleDurationInMins",
-        params,
-    )
+    params.insert("Integer".to_string(), integer.to_string());
+    super::call(service, "ascan", "action", "setOptionMaxRuleDurationInMins", params).await
 }
 
-pub fn set_option_max_scan_duration_in_mins(
-    service: &ZapService,
-    integer: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_max_scan_duration_in_mins(service: &ZapService, integer: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Integer".to_string(), integer);
-    super::call(
-        service,
-        "ascan",
-        "action",
-        "setOptionMaxScanDurationInMins",
-        params,
-    )
+    params.insert("Integer".to_string(), integer.to_string());
+    super::call(service, "ascan", "action", "setOptionMaxScanDurationInMins", params).await
 }
 
-pub fn set_option_max_scans_in_ui(
-    service: &ZapService,
-    integer: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_max_scans_in_ui(service: &ZapService, integer: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Integer".to_string(), integer);
-    super::call(service, "ascan", "action", "setOptionMaxScansInUI", params)
+    params.insert("Integer".to_string(), integer.to_string());
+    super::call(service, "ascan", "action", "setOptionMaxScansInUI", params).await
 }
 
-pub fn set_option_prompt_in_attack_mode(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_prompt_in_attack_mode(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "ascan",
-        "action",
-        "setOptionPromptInAttackMode",
-        params,
-    )
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "ascan", "action", "setOptionPromptInAttackMode", params).await
 }
 
-pub fn set_option_prompt_to_clear_finished_scans(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_prompt_to_clear_finished_scans(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "ascan",
-        "action",
-        "setOptionPromptToClearFinishedScans",
-        params,
-    )
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "ascan", "action", "setOptionPromptToClearFinishedScans", params).await
 }
 
-pub fn set_option_rescan_in_attack_mode(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_rescan_in_attack_mode(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "ascan",
-        "action",
-        "setOptionRescanInAttackMode",
-        params,
-    )
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "ascan", "action", "setOptionRescanInAttackMode", params).await
 }
 
 /**
  * Sets whether or not the HTTP Headers of all requests should be scanned. Not just requests that send parameters, through the query or request body.
 */
-pub fn set_option_scan_headers_all_requests(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_option_scan_headers_all_requests(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "ascan",
-        "action",
-        "setOptionScanHeadersAllRequests",
-        params,
-    )
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "ascan", "action", "setOptionScanHeadersAllRequests", params).await
 }
 
-pub fn set_option_show_advanced_dialog(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_show_advanced_dialog(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "ascan",
-        "action",
-        "setOptionShowAdvancedDialog",
-        params,
-    )
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "ascan", "action", "setOptionShowAdvancedDialog", params).await
 }
 
-pub fn set_option_target_params_enabled_rpc(
-    service: &ZapService,
-    integer: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_target_params_enabled_rpc(service: &ZapService, integer: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Integer".to_string(), integer);
-    super::call(
-        service,
-        "ascan",
-        "action",
-        "setOptionTargetParamsEnabledRPC",
-        params,
-    )
+    params.insert("Integer".to_string(), integer.to_string());
+    super::call(service, "ascan", "action", "setOptionTargetParamsEnabledRPC", params).await
 }
 
-pub fn set_option_target_params_injectable(
-    service: &ZapService,
-    integer: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_target_params_injectable(service: &ZapService, integer: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Integer".to_string(), integer);
-    super::call(
-        service,
-        "ascan",
-        "action",
-        "setOptionTargetParamsInjectable",
-        params,
-    )
+    params.insert("Integer".to_string(), integer.to_string());
+    super::call(service, "ascan", "action", "setOptionTargetParamsInjectable", params).await
 }
 
-pub fn set_option_thread_per_host(
-    service: &ZapService,
-    integer: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_thread_per_host(service: &ZapService, integer: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Integer".to_string(), integer);
-    super::call(service, "ascan", "action", "setOptionThreadPerHost", params)
+    params.insert("Integer".to_string(), integer.to_string());
+    super::call(service, "ascan", "action", "setOptionThreadPerHost", params).await
 }
+

--- a/src/authentication.rs
+++ b/src/authentication.rs
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 the ZAP development team
+ * Copyright 2020 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
  * limitations under the License.
  */
 
+
 use super::ZapApiError;
 use super::ZapService;
 use serde_json::Value;
 use std::collections::HashMap;
+
 
 /**
  * This file was automatically generated.
@@ -28,150 +30,75 @@ use std::collections::HashMap;
 /**
  * Gets the name of the authentication methods.
 */
-pub fn get_supported_authentication_methods(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn get_supported_authentication_methods(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "authentication",
-        "view",
-        "getSupportedAuthenticationMethods",
-        params,
-    )
+    super::call(service, "authentication", "view", "getSupportedAuthenticationMethods", params).await
 }
 
 /**
  * Gets the configuration parameters for the authentication method with the given name.
 */
-pub fn get_authentication_method_config_params(
-    service: &ZapService,
-    authmethodname: String,
-) -> Result<Value, ZapApiError> {
+pub async fn get_authentication_method_config_params(service: &ZapService, authmethodname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("authMethodName".to_string(), authmethodname);
-    super::call(
-        service,
-        "authentication",
-        "view",
-        "getAuthenticationMethodConfigParams",
-        params,
-    )
+    params.insert("authMethodName".to_string(), authmethodname.to_string());
+    super::call(service, "authentication", "view", "getAuthenticationMethodConfigParams", params).await
 }
 
 /**
  * Gets the name of the authentication method for the context with the given ID.
 */
-pub fn get_authentication_method(
-    service: &ZapService,
-    contextid: String,
-) -> Result<Value, ZapApiError> {
+pub async fn get_authentication_method(service: &ZapService, contextid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    super::call(
-        service,
-        "authentication",
-        "view",
-        "getAuthenticationMethod",
-        params,
-    )
+    params.insert("contextId".to_string(), contextid.to_string());
+    super::call(service, "authentication", "view", "getAuthenticationMethod", params).await
 }
 
 /**
  * Gets the logged in indicator for the context with the given ID.
 */
-pub fn get_logged_in_indicator(
-    service: &ZapService,
-    contextid: String,
-) -> Result<Value, ZapApiError> {
+pub async fn get_logged_in_indicator(service: &ZapService, contextid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    super::call(
-        service,
-        "authentication",
-        "view",
-        "getLoggedInIndicator",
-        params,
-    )
+    params.insert("contextId".to_string(), contextid.to_string());
+    super::call(service, "authentication", "view", "getLoggedInIndicator", params).await
 }
 
 /**
  * Gets the logged out indicator for the context with the given ID.
 */
-pub fn get_logged_out_indicator(
-    service: &ZapService,
-    contextid: String,
-) -> Result<Value, ZapApiError> {
+pub async fn get_logged_out_indicator(service: &ZapService, contextid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    super::call(
-        service,
-        "authentication",
-        "view",
-        "getLoggedOutIndicator",
-        params,
-    )
+    params.insert("contextId".to_string(), contextid.to_string());
+    super::call(service, "authentication", "view", "getLoggedOutIndicator", params).await
 }
 
 /**
  * Sets the authentication method for the context with the given ID.
 */
-pub fn set_authentication_method(
-    service: &ZapService,
-    contextid: String,
-    authmethodname: String,
-    authmethodconfigparams: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_authentication_method(service: &ZapService, contextid: &str, authmethodname: &str, authmethodconfigparams: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    params.insert("authMethodName".to_string(), authmethodname);
-    params.insert("authMethodConfigParams".to_string(), authmethodconfigparams);
-    super::call(
-        service,
-        "authentication",
-        "action",
-        "setAuthenticationMethod",
-        params,
-    )
+    params.insert("contextId".to_string(), contextid.to_string());
+    params.insert("authMethodName".to_string(), authmethodname.to_string());
+    params.insert("authMethodConfigParams".to_string(), authmethodconfigparams.to_string());
+    super::call(service, "authentication", "action", "setAuthenticationMethod", params).await
 }
 
 /**
  * Sets the logged in indicator for the context with the given ID.
 */
-pub fn set_logged_in_indicator(
-    service: &ZapService,
-    contextid: String,
-    loggedinindicatorregex: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_logged_in_indicator(service: &ZapService, contextid: &str, loggedinindicatorregex: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    params.insert("loggedInIndicatorRegex".to_string(), loggedinindicatorregex);
-    super::call(
-        service,
-        "authentication",
-        "action",
-        "setLoggedInIndicator",
-        params,
-    )
+    params.insert("contextId".to_string(), contextid.to_string());
+    params.insert("loggedInIndicatorRegex".to_string(), loggedinindicatorregex.to_string());
+    super::call(service, "authentication", "action", "setLoggedInIndicator", params).await
 }
 
 /**
  * Sets the logged out indicator for the context with the given ID.
 */
-pub fn set_logged_out_indicator(
-    service: &ZapService,
-    contextid: String,
-    loggedoutindicatorregex: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_logged_out_indicator(service: &ZapService, contextid: &str, loggedoutindicatorregex: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    params.insert(
-        "loggedOutIndicatorRegex".to_string(),
-        loggedoutindicatorregex,
-    );
-    super::call(
-        service,
-        "authentication",
-        "action",
-        "setLoggedOutIndicator",
-        params,
-    )
+    params.insert("contextId".to_string(), contextid.to_string());
+    params.insert("loggedOutIndicatorRegex".to_string(), loggedoutindicatorregex.to_string());
+    super::call(service, "authentication", "action", "setLoggedOutIndicator", params).await
 }
+

--- a/src/authorization.rs
+++ b/src/authorization.rs
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 the ZAP development team
+ * Copyright 2020 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
  * limitations under the License.
  */
 
+
 use super::ZapApiError;
 use super::ZapService;
 use serde_json::Value;
 use std::collections::HashMap;
+
 
 /**
  * This file was automatically generated.
@@ -28,43 +30,22 @@ use std::collections::HashMap;
 /**
  * Obtains all the configuration of the authorization detection method that is currently set for a context.
 */
-pub fn get_authorization_detection_method(
-    service: &ZapService,
-    contextid: String,
-) -> Result<Value, ZapApiError> {
+pub async fn get_authorization_detection_method(service: &ZapService, contextid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    super::call(
-        service,
-        "authorization",
-        "view",
-        "getAuthorizationDetectionMethod",
-        params,
-    )
+    params.insert("contextId".to_string(), contextid.to_string());
+    super::call(service, "authorization", "view", "getAuthorizationDetectionMethod", params).await
 }
 
 /**
  * Sets the authorization detection method for a context as one that identifies un-authorized messages based on: the message's status code or a regex pattern in the response's header or body. Also, whether all conditions must match or just some can be specified via the logicalOperator parameter, which accepts two values: "AND" (default), "OR".  
 */
-pub fn set_basic_authorization_detection_method(
-    service: &ZapService,
-    contextid: String,
-    headerregex: String,
-    bodyregex: String,
-    statuscode: String,
-    logicaloperator: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_basic_authorization_detection_method(service: &ZapService, contextid: &str, headerregex: &str, bodyregex: &str, statuscode: &str, logicaloperator: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    params.insert("headerRegex".to_string(), headerregex);
-    params.insert("bodyRegex".to_string(), bodyregex);
-    params.insert("statusCode".to_string(), statuscode);
-    params.insert("logicalOperator".to_string(), logicaloperator);
-    super::call(
-        service,
-        "authorization",
-        "action",
-        "setBasicAuthorizationDetectionMethod",
-        params,
-    )
+    params.insert("contextId".to_string(), contextid.to_string());
+    params.insert("headerRegex".to_string(), headerregex.to_string());
+    params.insert("bodyRegex".to_string(), bodyregex.to_string());
+    params.insert("statusCode".to_string(), statuscode.to_string());
+    params.insert("logicalOperator".to_string(), logicaloperator.to_string());
+    super::call(service, "authorization", "action", "setBasicAuthorizationDetectionMethod", params).await
 }
+

--- a/src/autoupdate.rs
+++ b/src/autoupdate.rs
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 the ZAP development team
+ * Copyright 2020 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
  * limitations under the License.
  */
 
+
 use super::ZapApiError;
 use super::ZapService;
 use serde_json::Value;
 use std::collections::HashMap;
+
 
 /**
  * This file was automatically generated.
@@ -28,350 +30,267 @@ use std::collections::HashMap;
 /**
  * Returns the latest version number
 */
-pub fn latest_version_number(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn latest_version_number(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "autoupdate", "view", "latestVersionNumber", params)
+    super::call(service, "autoupdate", "view", "latestVersionNumber", params).await
 }
 
 /**
  * Returns 'true' if ZAP is on the latest version
 */
-pub fn is_latest_version(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn is_latest_version(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "autoupdate", "view", "isLatestVersion", params)
+    super::call(service, "autoupdate", "view", "isLatestVersion", params).await
 }
 
 /**
  * Return a list of all of the installed add-ons
 */
-pub fn installed_addons(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn installed_addons(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "autoupdate", "view", "installedAddons", params)
+    super::call(service, "autoupdate", "view", "installedAddons", params).await
 }
 
 /**
  * Returns a list with all local add-ons, installed or not.
 */
-pub fn local_addons(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn local_addons(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "autoupdate", "view", "localAddons", params)
+    super::call(service, "autoupdate", "view", "localAddons", params).await
 }
 
 /**
  * Return a list of any add-ons that have been added to the Marketplace since the last check for updates
 */
-pub fn new_addons(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn new_addons(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "autoupdate", "view", "newAddons", params)
+    super::call(service, "autoupdate", "view", "newAddons", params).await
 }
 
 /**
  * Return a list of any add-ons that have been changed in the Marketplace since the last check for updates
 */
-pub fn updated_addons(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn updated_addons(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "autoupdate", "view", "updatedAddons", params)
+    super::call(service, "autoupdate", "view", "updatedAddons", params).await
 }
 
 /**
  * Return a list of all of the add-ons on the ZAP Marketplace (this information is read once and then cached)
 */
-pub fn marketplace_addons(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn marketplace_addons(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "autoupdate", "view", "marketplaceAddons", params)
-}
-
-pub fn option_addon_directories(service: &ZapService) -> Result<Value, ZapApiError> {
-    let params = HashMap::new();
-    super::call(
-        service,
-        "autoupdate",
-        "view",
-        "optionAddonDirectories",
-        params,
-    )
-}
-
-pub fn option_day_last_checked(service: &ZapService) -> Result<Value, ZapApiError> {
-    let params = HashMap::new();
-    super::call(
-        service,
-        "autoupdate",
-        "view",
-        "optionDayLastChecked",
-        params,
-    )
-}
-
-pub fn option_day_last_install_warned(service: &ZapService) -> Result<Value, ZapApiError> {
-    let params = HashMap::new();
-    super::call(
-        service,
-        "autoupdate",
-        "view",
-        "optionDayLastInstallWarned",
-        params,
-    )
-}
-
-pub fn option_day_last_update_warned(service: &ZapService) -> Result<Value, ZapApiError> {
-    let params = HashMap::new();
-    super::call(
-        service,
-        "autoupdate",
-        "view",
-        "optionDayLastUpdateWarned",
-        params,
-    )
-}
-
-pub fn option_download_directory(service: &ZapService) -> Result<Value, ZapApiError> {
-    let params = HashMap::new();
-    super::call(
-        service,
-        "autoupdate",
-        "view",
-        "optionDownloadDirectory",
-        params,
-    )
-}
-
-pub fn option_check_addon_updates(service: &ZapService) -> Result<Value, ZapApiError> {
-    let params = HashMap::new();
-    super::call(
-        service,
-        "autoupdate",
-        "view",
-        "optionCheckAddonUpdates",
-        params,
-    )
-}
-
-pub fn option_check_on_start(service: &ZapService) -> Result<Value, ZapApiError> {
-    let params = HashMap::new();
-    super::call(service, "autoupdate", "view", "optionCheckOnStart", params)
-}
-
-pub fn option_download_new_release(service: &ZapService) -> Result<Value, ZapApiError> {
-    let params = HashMap::new();
-    super::call(
-        service,
-        "autoupdate",
-        "view",
-        "optionDownloadNewRelease",
-        params,
-    )
-}
-
-pub fn option_install_addon_updates(service: &ZapService) -> Result<Value, ZapApiError> {
-    let params = HashMap::new();
-    super::call(
-        service,
-        "autoupdate",
-        "view",
-        "optionInstallAddonUpdates",
-        params,
-    )
-}
-
-pub fn option_install_scanner_rules(service: &ZapService) -> Result<Value, ZapApiError> {
-    let params = HashMap::new();
-    super::call(
-        service,
-        "autoupdate",
-        "view",
-        "optionInstallScannerRules",
-        params,
-    )
-}
-
-pub fn option_report_alpha_addons(service: &ZapService) -> Result<Value, ZapApiError> {
-    let params = HashMap::new();
-    super::call(
-        service,
-        "autoupdate",
-        "view",
-        "optionReportAlphaAddons",
-        params,
-    )
-}
-
-pub fn option_report_beta_addons(service: &ZapService) -> Result<Value, ZapApiError> {
-    let params = HashMap::new();
-    super::call(
-        service,
-        "autoupdate",
-        "view",
-        "optionReportBetaAddons",
-        params,
-    )
-}
-
-pub fn option_report_release_addons(service: &ZapService) -> Result<Value, ZapApiError> {
-    let params = HashMap::new();
-    super::call(
-        service,
-        "autoupdate",
-        "view",
-        "optionReportReleaseAddons",
-        params,
-    )
+    super::call(service, "autoupdate", "view", "marketplaceAddons", params).await
 }
 
 /**
- * Downloads the latest release, if any
+ * 
 */
-pub fn download_latest_release(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_addon_directories(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "autoupdate",
-        "action",
-        "downloadLatestRelease",
-        params,
-    )
+    super::call(service, "autoupdate", "view", "optionAddonDirectories", params).await
 }
 
 /**
- * Installs or updates the specified add-on, returning when complete (ie not asynchronously)
+ * 
 */
-pub fn install_addon(service: &ZapService, id: String) -> Result<Value, ZapApiError> {
-    let mut params = HashMap::new();
-    params.insert("id".to_string(), id);
-    super::call(service, "autoupdate", "action", "installAddon", params)
-}
-
-pub fn install_local_addon(service: &ZapService, file: String) -> Result<Value, ZapApiError> {
-    let mut params = HashMap::new();
-    params.insert("file".to_string(), file);
-    super::call(service, "autoupdate", "action", "installLocalAddon", params)
+pub async fn option_day_last_checked(service: &ZapService) -> Result<Value, ZapApiError> {
+    let params = HashMap::new();
+    super::call(service, "autoupdate", "view", "optionDayLastChecked", params).await
 }
 
 /**
- * Uninstalls the specified add-on
+ * 
 */
-pub fn uninstall_addon(service: &ZapService, id: String) -> Result<Value, ZapApiError> {
-    let mut params = HashMap::new();
-    params.insert("id".to_string(), id);
-    super::call(service, "autoupdate", "action", "uninstallAddon", params)
+pub async fn option_day_last_install_warned(service: &ZapService) -> Result<Value, ZapApiError> {
+    let params = HashMap::new();
+    super::call(service, "autoupdate", "view", "optionDayLastInstallWarned", params).await
 }
 
-pub fn set_option_check_addon_updates(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
-    let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "autoupdate",
-        "action",
-        "setOptionCheckAddonUpdates",
-        params,
-    )
+/**
+ * 
+*/
+pub async fn option_day_last_update_warned(service: &ZapService) -> Result<Value, ZapApiError> {
+    let params = HashMap::new();
+    super::call(service, "autoupdate", "view", "optionDayLastUpdateWarned", params).await
 }
 
-pub fn set_option_check_on_start(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
-    let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "autoupdate",
-        "action",
-        "setOptionCheckOnStart",
-        params,
-    )
+/**
+ * 
+*/
+pub async fn option_download_directory(service: &ZapService) -> Result<Value, ZapApiError> {
+    let params = HashMap::new();
+    super::call(service, "autoupdate", "view", "optionDownloadDirectory", params).await
 }
 
-pub fn set_option_download_new_release(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
-    let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "autoupdate",
-        "action",
-        "setOptionDownloadNewRelease",
-        params,
-    )
+/**
+ * 
+*/
+pub async fn option_check_addon_updates(service: &ZapService) -> Result<Value, ZapApiError> {
+    let params = HashMap::new();
+    super::call(service, "autoupdate", "view", "optionCheckAddonUpdates", params).await
 }
 
-pub fn set_option_install_addon_updates(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
-    let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "autoupdate",
-        "action",
-        "setOptionInstallAddonUpdates",
-        params,
-    )
+/**
+ * 
+*/
+pub async fn option_check_on_start(service: &ZapService) -> Result<Value, ZapApiError> {
+    let params = HashMap::new();
+    super::call(service, "autoupdate", "view", "optionCheckOnStart", params).await
 }
 
-pub fn set_option_install_scanner_rules(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
-    let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "autoupdate",
-        "action",
-        "setOptionInstallScannerRules",
-        params,
-    )
+/**
+ * 
+*/
+pub async fn option_download_new_release(service: &ZapService) -> Result<Value, ZapApiError> {
+    let params = HashMap::new();
+    super::call(service, "autoupdate", "view", "optionDownloadNewRelease", params).await
 }
 
-pub fn set_option_report_alpha_addons(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
-    let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "autoupdate",
-        "action",
-        "setOptionReportAlphaAddons",
-        params,
-    )
+/**
+ * 
+*/
+pub async fn option_install_addon_updates(service: &ZapService) -> Result<Value, ZapApiError> {
+    let params = HashMap::new();
+    super::call(service, "autoupdate", "view", "optionInstallAddonUpdates", params).await
 }
 
-pub fn set_option_report_beta_addons(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
-    let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "autoupdate",
-        "action",
-        "setOptionReportBetaAddons",
-        params,
-    )
+/**
+ * 
+*/
+pub async fn option_install_scanner_rules(service: &ZapService) -> Result<Value, ZapApiError> {
+    let params = HashMap::new();
+    super::call(service, "autoupdate", "view", "optionInstallScannerRules", params).await
 }
 
-pub fn set_option_report_release_addons(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
-    let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "autoupdate",
-        "action",
-        "setOptionReportReleaseAddons",
-        params,
-    )
+/**
+ * 
+*/
+pub async fn option_report_alpha_addons(service: &ZapService) -> Result<Value, ZapApiError> {
+    let params = HashMap::new();
+    super::call(service, "autoupdate", "view", "optionReportAlphaAddons", params).await
 }
+
+/**
+ * 
+*/
+pub async fn option_report_beta_addons(service: &ZapService) -> Result<Value, ZapApiError> {
+    let params = HashMap::new();
+    super::call(service, "autoupdate", "view", "optionReportBetaAddons", params).await
+}
+
+/**
+ * 
+*/
+pub async fn option_report_release_addons(service: &ZapService) -> Result<Value, ZapApiError> {
+    let params = HashMap::new();
+    super::call(service, "autoupdate", "view", "optionReportReleaseAddons", params).await
+}
+
+/**
+ * Downloads the latest release, if any 
+*/
+pub async fn download_latest_release(service: &ZapService) -> Result<Value, ZapApiError> {
+    let params = HashMap::new();
+    super::call(service, "autoupdate", "action", "downloadLatestRelease", params).await
+}
+
+/**
+ * Installs or updates the specified add-on, returning when complete (i.e. not asynchronously)
+*/
+pub async fn install_addon(service: &ZapService, id: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("id".to_string(), id.to_string());
+    super::call(service, "autoupdate", "action", "installAddon", params).await
+}
+
+/**
+ * 
+*/
+pub async fn install_local_addon(service: &ZapService, file: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("file".to_string(), file.to_string());
+    super::call(service, "autoupdate", "action", "installLocalAddon", params).await
+}
+
+/**
+ * Uninstalls the specified add-on 
+*/
+pub async fn uninstall_addon(service: &ZapService, id: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("id".to_string(), id.to_string());
+    super::call(service, "autoupdate", "action", "uninstallAddon", params).await
+}
+
+/**
+ * 
+*/
+pub async fn set_option_check_addon_updates(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "autoupdate", "action", "setOptionCheckAddonUpdates", params).await
+}
+
+/**
+ * 
+*/
+pub async fn set_option_check_on_start(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "autoupdate", "action", "setOptionCheckOnStart", params).await
+}
+
+/**
+ * 
+*/
+pub async fn set_option_download_new_release(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "autoupdate", "action", "setOptionDownloadNewRelease", params).await
+}
+
+/**
+ * 
+*/
+pub async fn set_option_install_addon_updates(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "autoupdate", "action", "setOptionInstallAddonUpdates", params).await
+}
+
+/**
+ * 
+*/
+pub async fn set_option_install_scanner_rules(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "autoupdate", "action", "setOptionInstallScannerRules", params).await
+}
+
+/**
+ * 
+*/
+pub async fn set_option_report_alpha_addons(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "autoupdate", "action", "setOptionReportAlphaAddons", params).await
+}
+
+/**
+ * 
+*/
+pub async fn set_option_report_beta_addons(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "autoupdate", "action", "setOptionReportBetaAddons", params).await
+}
+
+/**
+ * 
+*/
+pub async fn set_option_report_release_addons(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "autoupdate", "action", "setOptionReportReleaseAddons", params).await
+}
+

--- a/src/brk.rs
+++ b/src/brk.rs
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 the ZAP development team
+ * Copyright 2020 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
  * limitations under the License.
  */
 
+
 use super::ZapApiError;
 use super::ZapService;
 use serde_json::Value;
 use std::collections::HashMap;
+
 
 /**
  * This file was automatically generated.
@@ -28,125 +30,103 @@ use std::collections::HashMap;
 /**
  * Returns True if ZAP will break on both requests and responses
 */
-pub fn is_break_all(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn is_break_all(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "break", "view", "isBreakAll", params)
+    super::call(service, "break", "view", "isBreakAll", params).await
 }
 
 /**
  * Returns True if ZAP will break on requests
 */
-pub fn is_break_request(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn is_break_request(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "break", "view", "isBreakRequest", params)
+    super::call(service, "break", "view", "isBreakRequest", params).await
 }
 
 /**
  * Returns True if ZAP will break on responses
 */
-pub fn is_break_response(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn is_break_response(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "break", "view", "isBreakResponse", params)
+    super::call(service, "break", "view", "isBreakResponse", params).await
 }
 
 /**
  * Returns the HTTP message currently intercepted (if any)
 */
-pub fn http_message(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn http_message(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "break", "view", "httpMessage", params)
+    super::call(service, "break", "view", "httpMessage", params).await
 }
 
 /**
  * Controls the global break functionality. The type may be one of: http-all, http-request or http-response. The state may be true (for turning break on for the specified type) or false (for turning break off). Scope is not currently used.
 */
-pub fn brk(
-    service: &ZapService,
-    typ: String,
-    state: String,
-    scope: String,
-) -> Result<Value, ZapApiError> {
+pub async fn brk(service: &ZapService, typ: &str, state: &str, scope: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("type".to_string(), typ);
-    params.insert("state".to_string(), state);
-    params.insert("scope".to_string(), scope);
-    super::call(service, "break", "action", "break", params)
+    params.insert("type".to_string(), typ.to_string());
+    params.insert("state".to_string(), state.to_string());
+    params.insert("scope".to_string(), scope.to_string());
+    super::call(service, "break", "action", "break", params).await
 }
 
 /**
  * Overwrites the currently intercepted message with the data provided
 */
-pub fn set_http_message(
-    service: &ZapService,
-    httpheader: String,
-    httpbody: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_http_message(service: &ZapService, httpheader: &str, httpbody: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("httpHeader".to_string(), httpheader);
-    params.insert("httpBody".to_string(), httpbody);
-    super::call(service, "break", "action", "setHttpMessage", params)
+    params.insert("httpHeader".to_string(), httpheader.to_string());
+    params.insert("httpBody".to_string(), httpbody.to_string());
+    super::call(service, "break", "action", "setHttpMessage", params).await
 }
 
 /**
- * Submits the currently intercepted message and unsets the global request/response break points
+ * Submits the currently intercepted message and unsets the global request/response breakpoints
 */
-pub fn cont(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn cont(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "break", "action", "continue", params)
+    super::call(service, "break", "action", "continue", params).await
 }
 
 /**
  * Submits the currently intercepted message, the next request or response will automatically be intercepted
 */
-pub fn step(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn step(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "break", "action", "step", params)
+    super::call(service, "break", "action", "step", params).await
 }
 
 /**
  * Drops the currently intercepted message
 */
-pub fn drop(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn drop(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "break", "action", "drop", params)
+    super::call(service, "break", "action", "drop", params).await
 }
 
 /**
- * Adds a custom HTTP breakpont. The string is the string to match. Location may be one of: url, request_header, request_body, response_header or response_body. Match may be: contains or regex. Inverse (match) may be true or false. Lastly, ignorecase (when matching the string) may be true or false.  
+ * Adds a custom HTTP breakpoint. The string is the string to match. Location may be one of: url, request_header, request_body, response_header or response_body. Match may be: contains or regex. Inverse (match) may be true or false. Lastly, ignorecase (when matching the string) may be true or false.  
 */
-pub fn add_http_breakpoint(
-    service: &ZapService,
-    string: String,
-    location: String,
-    mtch: String,
-    inverse: String,
-    ignorecase: String,
-) -> Result<Value, ZapApiError> {
+pub async fn add_http_breakpoint(service: &ZapService, string: &str, location: &str, mtch: &str, inverse: &str, ignorecase: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("string".to_string(), string);
-    params.insert("location".to_string(), location);
-    params.insert("match".to_string(), mtch);
-    params.insert("inverse".to_string(), inverse);
-    params.insert("ignorecase".to_string(), ignorecase);
-    super::call(service, "break", "action", "addHttpBreakpoint", params)
+    params.insert("string".to_string(), string.to_string());
+    params.insert("location".to_string(), location.to_string());
+    params.insert("match".to_string(), mtch.to_string());
+    params.insert("inverse".to_string(), inverse.to_string());
+    params.insert("ignorecase".to_string(), ignorecase.to_string());
+    super::call(service, "break", "action", "addHttpBreakpoint", params).await
 }
 
 /**
- * Removes the specified break point
+ * Removes the specified breakpoint
 */
-pub fn remove_http_breakpoint(
-    service: &ZapService,
-    string: String,
-    location: String,
-    mtch: String,
-    inverse: String,
-    ignorecase: String,
-) -> Result<Value, ZapApiError> {
+pub async fn remove_http_breakpoint(service: &ZapService, string: &str, location: &str, mtch: &str, inverse: &str, ignorecase: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("string".to_string(), string);
-    params.insert("location".to_string(), location);
-    params.insert("match".to_string(), mtch);
-    params.insert("inverse".to_string(), inverse);
-    params.insert("ignorecase".to_string(), ignorecase);
-    super::call(service, "break", "action", "removeHttpBreakpoint", params)
+    params.insert("string".to_string(), string.to_string());
+    params.insert("location".to_string(), location.to_string());
+    params.insert("match".to_string(), mtch.to_string());
+    params.insert("inverse".to_string(), inverse.to_string());
+    params.insert("ignorecase".to_string(), ignorecase.to_string());
+    super::call(service, "break", "action", "removeHttpBreakpoint", params).await
 }
+

--- a/src/context.rs
+++ b/src/context.rs
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 the ZAP development team
+ * Copyright 2020 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
  * limitations under the License.
  */
 
+
 use super::ZapApiError;
 use super::ZapService;
 use serde_json::Value;
 use std::collections::HashMap;
+
 
 /**
  * This file was automatically generated.
@@ -28,250 +30,186 @@ use std::collections::HashMap;
 /**
  * List context names of current session
 */
-pub fn context_list(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn context_list(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "context", "view", "contextList", params)
+    super::call(service, "context", "view", "contextList", params).await
 }
 
 /**
  * List excluded regexs for context
 */
-pub fn exclude_regexs(service: &ZapService, contextname: String) -> Result<Value, ZapApiError> {
+pub async fn exclude_regexs(service: &ZapService, contextname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextName".to_string(), contextname);
-    super::call(service, "context", "view", "excludeRegexs", params)
+    params.insert("contextName".to_string(), contextname.to_string());
+    super::call(service, "context", "view", "excludeRegexs", params).await
 }
 
 /**
  * List included regexs for context
 */
-pub fn include_regexs(service: &ZapService, contextname: String) -> Result<Value, ZapApiError> {
+pub async fn include_regexs(service: &ZapService, contextname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextName".to_string(), contextname);
-    super::call(service, "context", "view", "includeRegexs", params)
+    params.insert("contextName".to_string(), contextname.to_string());
+    super::call(service, "context", "view", "includeRegexs", params).await
 }
 
 /**
  * List the information about the named context
 */
-pub fn context(service: &ZapService, contextname: String) -> Result<Value, ZapApiError> {
+pub async fn context(service: &ZapService, contextname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextName".to_string(), contextname);
-    super::call(service, "context", "view", "context", params)
+    params.insert("contextName".to_string(), contextname.to_string());
+    super::call(service, "context", "view", "context", params).await
 }
 
 /**
  * Lists the names of all built in technologies
 */
-pub fn technology_list(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn technology_list(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "context", "view", "technologyList", params)
+    super::call(service, "context", "view", "technologyList", params).await
 }
 
 /**
  * Lists the names of all technologies included in a context
 */
-pub fn included_technology_list(
-    service: &ZapService,
-    contextname: String,
-) -> Result<Value, ZapApiError> {
+pub async fn included_technology_list(service: &ZapService, contextname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextName".to_string(), contextname);
-    super::call(service, "context", "view", "includedTechnologyList", params)
+    params.insert("contextName".to_string(), contextname.to_string());
+    super::call(service, "context", "view", "includedTechnologyList", params).await
 }
 
 /**
  * Lists the names of all technologies excluded from a context
 */
-pub fn excluded_technology_list(
-    service: &ZapService,
-    contextname: String,
-) -> Result<Value, ZapApiError> {
+pub async fn excluded_technology_list(service: &ZapService, contextname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextName".to_string(), contextname);
-    super::call(service, "context", "view", "excludedTechnologyList", params)
+    params.insert("contextName".to_string(), contextname.to_string());
+    super::call(service, "context", "view", "excludedTechnologyList", params).await
 }
 
 /**
  * Lists the URLs accessed through/by ZAP, that belong to the context with the given name.
 */
-pub fn urls(service: &ZapService, contextname: String) -> Result<Value, ZapApiError> {
+pub async fn urls(service: &ZapService, contextname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextName".to_string(), contextname);
-    super::call(service, "context", "view", "urls", params)
+    params.insert("contextName".to_string(), contextname.to_string());
+    super::call(service, "context", "view", "urls", params).await
 }
 
 /**
  * Add exclude regex to context
 */
-pub fn exclude_from_context(
-    service: &ZapService,
-    contextname: String,
-    regex: String,
-) -> Result<Value, ZapApiError> {
+pub async fn exclude_from_context(service: &ZapService, contextname: &str, regex: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextName".to_string(), contextname);
-    params.insert("regex".to_string(), regex);
-    super::call(service, "context", "action", "excludeFromContext", params)
+    params.insert("contextName".to_string(), contextname.to_string());
+    params.insert("regex".to_string(), regex.to_string());
+    super::call(service, "context", "action", "excludeFromContext", params).await
 }
 
 /**
  * Add include regex to context
 */
-pub fn include_in_context(
-    service: &ZapService,
-    contextname: String,
-    regex: String,
-) -> Result<Value, ZapApiError> {
+pub async fn include_in_context(service: &ZapService, contextname: &str, regex: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextName".to_string(), contextname);
-    params.insert("regex".to_string(), regex);
-    super::call(service, "context", "action", "includeInContext", params)
+    params.insert("contextName".to_string(), contextname.to_string());
+    params.insert("regex".to_string(), regex.to_string());
+    super::call(service, "context", "action", "includeInContext", params).await
 }
 
 /**
  * Set the regexs to include and exclude for a context, both supplied as JSON string arrays
 */
-pub fn set_context_regexs(
-    service: &ZapService,
-    contextname: String,
-    incregexs: String,
-    excregexs: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_context_regexs(service: &ZapService, contextname: &str, incregexs: &str, excregexs: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextName".to_string(), contextname);
-    params.insert("incRegexs".to_string(), incregexs);
-    params.insert("excRegexs".to_string(), excregexs);
-    super::call(service, "context", "action", "setContextRegexs", params)
+    params.insert("contextName".to_string(), contextname.to_string());
+    params.insert("incRegexs".to_string(), incregexs.to_string());
+    params.insert("excRegexs".to_string(), excregexs.to_string());
+    super::call(service, "context", "action", "setContextRegexs", params).await
 }
 
 /**
  * Creates a new context with the given name in the current session
 */
-pub fn new_context(service: &ZapService, contextname: String) -> Result<Value, ZapApiError> {
+pub async fn new_context(service: &ZapService, contextname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextName".to_string(), contextname);
-    super::call(service, "context", "action", "newContext", params)
+    params.insert("contextName".to_string(), contextname.to_string());
+    super::call(service, "context", "action", "newContext", params).await
 }
 
 /**
  * Removes a context in the current session
 */
-pub fn remove_context(service: &ZapService, contextname: String) -> Result<Value, ZapApiError> {
+pub async fn remove_context(service: &ZapService, contextname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextName".to_string(), contextname);
-    super::call(service, "context", "action", "removeContext", params)
+    params.insert("contextName".to_string(), contextname.to_string());
+    super::call(service, "context", "action", "removeContext", params).await
 }
 
 /**
  * Exports the context with the given name to a file. If a relative file path is specified it will be resolved against the "contexts" directory in ZAP "home" dir.
 */
-pub fn export_context(
-    service: &ZapService,
-    contextname: String,
-    contextfile: String,
-) -> Result<Value, ZapApiError> {
+pub async fn export_context(service: &ZapService, contextname: &str, contextfile: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextName".to_string(), contextname);
-    params.insert("contextFile".to_string(), contextfile);
-    super::call(service, "context", "action", "exportContext", params)
+    params.insert("contextName".to_string(), contextname.to_string());
+    params.insert("contextFile".to_string(), contextfile.to_string());
+    super::call(service, "context", "action", "exportContext", params).await
 }
 
 /**
  * Imports a context from a file. If a relative file path is specified it will be resolved against the "contexts" directory in ZAP "home" dir.
 */
-pub fn import_context(service: &ZapService, contextfile: String) -> Result<Value, ZapApiError> {
+pub async fn import_context(service: &ZapService, contextfile: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextFile".to_string(), contextfile);
-    super::call(service, "context", "action", "importContext", params)
+    params.insert("contextFile".to_string(), contextfile.to_string());
+    super::call(service, "context", "action", "importContext", params).await
 }
 
 /**
  * Includes technologies with the given names, separated by a comma, to a context
 */
-pub fn include_context_technologies(
-    service: &ZapService,
-    contextname: String,
-    technologynames: String,
-) -> Result<Value, ZapApiError> {
+pub async fn include_context_technologies(service: &ZapService, contextname: &str, technologynames: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextName".to_string(), contextname);
-    params.insert("technologyNames".to_string(), technologynames);
-    super::call(
-        service,
-        "context",
-        "action",
-        "includeContextTechnologies",
-        params,
-    )
+    params.insert("contextName".to_string(), contextname.to_string());
+    params.insert("technologyNames".to_string(), technologynames.to_string());
+    super::call(service, "context", "action", "includeContextTechnologies", params).await
 }
 
 /**
  * Includes all built in technologies in to a context
 */
-pub fn include_all_context_technologies(
-    service: &ZapService,
-    contextname: String,
-) -> Result<Value, ZapApiError> {
+pub async fn include_all_context_technologies(service: &ZapService, contextname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextName".to_string(), contextname);
-    super::call(
-        service,
-        "context",
-        "action",
-        "includeAllContextTechnologies",
-        params,
-    )
+    params.insert("contextName".to_string(), contextname.to_string());
+    super::call(service, "context", "action", "includeAllContextTechnologies", params).await
 }
 
 /**
  * Excludes technologies with the given names, separated by a comma, from a context
 */
-pub fn exclude_context_technologies(
-    service: &ZapService,
-    contextname: String,
-    technologynames: String,
-) -> Result<Value, ZapApiError> {
+pub async fn exclude_context_technologies(service: &ZapService, contextname: &str, technologynames: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextName".to_string(), contextname);
-    params.insert("technologyNames".to_string(), technologynames);
-    super::call(
-        service,
-        "context",
-        "action",
-        "excludeContextTechnologies",
-        params,
-    )
+    params.insert("contextName".to_string(), contextname.to_string());
+    params.insert("technologyNames".to_string(), technologynames.to_string());
+    super::call(service, "context", "action", "excludeContextTechnologies", params).await
 }
 
 /**
  * Excludes all built in technologies from a context
 */
-pub fn exclude_all_context_technologies(
-    service: &ZapService,
-    contextname: String,
-) -> Result<Value, ZapApiError> {
+pub async fn exclude_all_context_technologies(service: &ZapService, contextname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextName".to_string(), contextname);
-    super::call(
-        service,
-        "context",
-        "action",
-        "excludeAllContextTechnologies",
-        params,
-    )
+    params.insert("contextName".to_string(), contextname.to_string());
+    super::call(service, "context", "action", "excludeAllContextTechnologies", params).await
 }
 
 /**
  * Sets a context to in scope (contexts are in scope by default)
 */
-pub fn set_context_in_scope(
-    service: &ZapService,
-    contextname: String,
-    booleaninscope: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_context_in_scope(service: &ZapService, contextname: &str, booleaninscope: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextName".to_string(), contextname);
-    params.insert("booleanInScope".to_string(), booleaninscope);
-    super::call(service, "context", "action", "setContextInScope", params)
+    params.insert("contextName".to_string(), contextname.to_string());
+    params.insert("booleanInScope".to_string(), booleaninscope.to_string());
+    super::call(service, "context", "action", "setContextInScope", params).await
 }
+

--- a/src/core.rs
+++ b/src/core.rs
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 the ZAP development team
+ * Copyright 2020 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
  * limitations under the License.
  */
 
+
 use super::ZapApiError;
 use super::ZapService;
 use serde_json::Value;
 use std::collections::HashMap;
+
 
 /**
  * This file was automatically generated.
@@ -28,1001 +30,817 @@ use std::collections::HashMap;
 /**
  * Gets the name of the hosts accessed through/by ZAP
 */
-pub fn hosts(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn hosts(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "hosts", params)
+    super::call(service, "core", "view", "hosts", params).await
 }
 
 /**
  * Gets the sites accessed through/by ZAP (scheme and domain)
 */
-pub fn sites(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn sites(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "sites", params)
+    super::call(service, "core", "view", "sites", params).await
 }
 
 /**
  * Gets the URLs accessed through/by ZAP, optionally filtering by (base) URL.
 */
-pub fn urls(service: &ZapService, baseurl: String) -> Result<Value, ZapApiError> {
+pub async fn urls(service: &ZapService, baseurl: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("baseurl".to_string(), baseurl);
-    super::call(service, "core", "view", "urls", params)
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    super::call(service, "core", "view", "urls", params).await
 }
 
 /**
  * Gets the child nodes underneath the specified URL in the Sites tree
 */
-pub fn child_nodes(service: &ZapService, url: String) -> Result<Value, ZapApiError> {
+pub async fn child_nodes(service: &ZapService, url: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("url".to_string(), url);
-    super::call(service, "core", "view", "childNodes", params)
+    params.insert("url".to_string(), url.to_string());
+    super::call(service, "core", "view", "childNodes", params).await
 }
 
 /**
  * Gets the HTTP message with the given ID. Returns the ID, request/response headers and bodies, cookies, note, type, RTT, and timestamp.
 */
-pub fn message(service: &ZapService, id: String) -> Result<Value, ZapApiError> {
+pub async fn message(service: &ZapService, id: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("id".to_string(), id);
-    super::call(service, "core", "view", "message", params)
+    params.insert("id".to_string(), id.to_string());
+    super::call(service, "core", "view", "message", params).await
 }
 
 /**
  * Gets the HTTP messages sent by ZAP, request and response, optionally filtered by URL and paginated with 'start' position and 'count' of messages
 */
-pub fn messages(
-    service: &ZapService,
-    baseurl: String,
-    start: String,
-    count: String,
-) -> Result<Value, ZapApiError> {
+pub async fn messages(service: &ZapService, baseurl: &str, start: &str, count: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("baseurl".to_string(), baseurl);
-    params.insert("start".to_string(), start);
-    params.insert("count".to_string(), count);
-    super::call(service, "core", "view", "messages", params)
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    params.insert("start".to_string(), start.to_string());
+    params.insert("count".to_string(), count.to_string());
+    super::call(service, "core", "view", "messages", params).await
 }
 
 /**
  * Gets the HTTP messages with the given IDs.
 */
-pub fn messages_by_id(service: &ZapService, ids: String) -> Result<Value, ZapApiError> {
+pub async fn messages_by_id(service: &ZapService, ids: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("ids".to_string(), ids);
-    super::call(service, "core", "view", "messagesById", params)
+    params.insert("ids".to_string(), ids.to_string());
+    super::call(service, "core", "view", "messagesById", params).await
 }
 
 /**
  * Gets the number of messages, optionally filtering by URL
 */
-pub fn number_of_messages(service: &ZapService, baseurl: String) -> Result<Value, ZapApiError> {
+pub async fn number_of_messages(service: &ZapService, baseurl: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("baseurl".to_string(), baseurl);
-    super::call(service, "core", "view", "numberOfMessages", params)
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    super::call(service, "core", "view", "numberOfMessages", params).await
 }
 
 /**
  * Gets the mode
 */
-pub fn mode(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn mode(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "mode", params)
+    super::call(service, "core", "view", "mode", params).await
 }
 
 /**
  * Gets ZAP version
 */
-pub fn version(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn version(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "version", params)
+    super::call(service, "core", "view", "version", params).await
 }
 
 /**
  * Gets the regular expressions, applied to URLs, to exclude from the local proxies.
 */
-pub fn excluded_from_proxy(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn excluded_from_proxy(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "excludedFromProxy", params)
+    super::call(service, "core", "view", "excludedFromProxy", params).await
 }
 
-pub fn home_directory(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn home_directory(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "homeDirectory", params)
+    super::call(service, "core", "view", "homeDirectory", params).await
 }
 
 /**
  * Gets the location of the current session file
 */
-pub fn session_location(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn session_location(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "sessionLocation", params)
+    super::call(service, "core", "view", "sessionLocation", params).await
 }
 
 /**
  * Gets all the domains that are excluded from the outgoing proxy. For each domain the following are shown: the index, the value (domain), if enabled, and if specified as a regex.
 */
-pub fn proxy_chain_excluded_domains(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn proxy_chain_excluded_domains(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "proxyChainExcludedDomains", params)
+    super::call(service, "core", "view", "proxyChainExcludedDomains", params).await
 }
 
 /**
  * Use view proxyChainExcludedDomains instead.
- * Deprecated
 */
-pub fn option_proxy_chain_skip_name(service: &ZapService) -> Result<Value, ZapApiError> {
+#[deprecated]
+pub async fn option_proxy_chain_skip_name(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "optionProxyChainSkipName", params)
+    super::call(service, "core", "view", "optionProxyChainSkipName", params).await
 }
 
 /**
  * Use view proxyChainExcludedDomains instead.
- * Deprecated
 */
-pub fn option_proxy_excluded_domains(service: &ZapService) -> Result<Value, ZapApiError> {
+#[deprecated]
+pub async fn option_proxy_excluded_domains(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "core",
-        "view",
-        "optionProxyExcludedDomains",
-        params,
-    )
+    super::call(service, "core", "view", "optionProxyExcludedDomains", params).await
 }
 
 /**
  * Use view proxyChainExcludedDomains instead.
- * Deprecated
 */
-pub fn option_proxy_excluded_domains_enabled(service: &ZapService) -> Result<Value, ZapApiError> {
+#[deprecated]
+pub async fn option_proxy_excluded_domains_enabled(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "core",
-        "view",
-        "optionProxyExcludedDomainsEnabled",
-        params,
-    )
+    super::call(service, "core", "view", "optionProxyExcludedDomainsEnabled", params).await
 }
 
 /**
  * Gets the path to ZAP's home directory.
 */
-pub fn zap_home_path(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn zap_home_path(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "zapHomePath", params)
+    super::call(service, "core", "view", "zapHomePath", params).await
 }
 
 /**
  * Gets the maximum number of alert instances to include in a report.
 */
-pub fn option_maximum_alert_instances(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_maximum_alert_instances(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "core",
-        "view",
-        "optionMaximumAlertInstances",
-        params,
-    )
+    super::call(service, "core", "view", "optionMaximumAlertInstances", params).await
 }
 
 /**
  * Gets whether or not related alerts will be merged in any reports generated.
 */
-pub fn option_merge_related_alerts(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_merge_related_alerts(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "optionMergeRelatedAlerts", params)
+    super::call(service, "core", "view", "optionMergeRelatedAlerts", params).await
 }
 
 /**
  * Gets the path to the file with alert overrides.
 */
-pub fn option_alert_overrides_file_path(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_alert_overrides_file_path(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "core",
-        "view",
-        "optionAlertOverridesFilePath",
-        params,
-    )
+    super::call(service, "core", "view", "optionAlertOverridesFilePath", params).await
 }
 
 /**
  * Gets the alert with the given ID, the corresponding HTTP message can be obtained with the 'messageId' field and 'message' API method
- * Deprecated Use the API endpoint with the same name in the 'alert' component instead.
 */
-pub fn alert(service: &ZapService, id: String) -> Result<Value, ZapApiError> {
+#[deprecated(note="Use the API endpoint with the same name in the 'alert' component instead.")]
+pub async fn alert(service: &ZapService, id: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("id".to_string(), id);
-    super::call(service, "core", "view", "alert", params)
+    params.insert("id".to_string(), id.to_string());
+    super::call(service, "core", "view", "alert", params).await
 }
 
 /**
  * Gets the alerts raised by ZAP, optionally filtering by URL or riskId, and paginating with 'start' position and 'count' of alerts
- * Deprecated Use the API endpoint with the same name in the 'alert' component instead.
 */
-pub fn alerts(
-    service: &ZapService,
-    baseurl: String,
-    start: String,
-    count: String,
-    riskid: String,
-) -> Result<Value, ZapApiError> {
+#[deprecated(note="Use the API endpoint with the same name in the 'alert' component instead.")]
+pub async fn alerts(service: &ZapService, baseurl: &str, start: &str, count: &str, riskid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("baseurl".to_string(), baseurl);
-    params.insert("start".to_string(), start);
-    params.insert("count".to_string(), count);
-    params.insert("riskId".to_string(), riskid);
-    super::call(service, "core", "view", "alerts", params)
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    params.insert("start".to_string(), start.to_string());
+    params.insert("count".to_string(), count.to_string());
+    params.insert("riskId".to_string(), riskid.to_string());
+    super::call(service, "core", "view", "alerts", params).await
 }
 
 /**
  * Gets number of alerts grouped by each risk level, optionally filtering by URL
- * Deprecated Use the API endpoint with the same name in the 'alert' component instead.
 */
-pub fn alerts_summary(service: &ZapService, baseurl: String) -> Result<Value, ZapApiError> {
+#[deprecated(note="Use the API endpoint with the same name in the 'alert' component instead.")]
+pub async fn alerts_summary(service: &ZapService, baseurl: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("baseurl".to_string(), baseurl);
-    super::call(service, "core", "view", "alertsSummary", params)
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    super::call(service, "core", "view", "alertsSummary", params).await
 }
 
 /**
  * Gets the number of alerts, optionally filtering by URL or riskId
- * Deprecated Use the API endpoint with the same name in the 'alert' component instead.
 */
-pub fn number_of_alerts(
-    service: &ZapService,
-    baseurl: String,
-    riskid: String,
-) -> Result<Value, ZapApiError> {
+#[deprecated(note="Use the API endpoint with the same name in the 'alert' component instead.")]
+pub async fn number_of_alerts(service: &ZapService, baseurl: &str, riskid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("baseurl".to_string(), baseurl);
-    params.insert("riskId".to_string(), riskid);
-    super::call(service, "core", "view", "numberOfAlerts", params)
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    params.insert("riskId".to_string(), riskid.to_string());
+    super::call(service, "core", "view", "numberOfAlerts", params).await
 }
 
 /**
  * Gets the user agent that ZAP should use when creating HTTP messages (for example, spider messages or CONNECT requests to outgoing proxy).
 */
-pub fn option_default_user_agent(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_default_user_agent(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "optionDefaultUserAgent", params)
+    super::call(service, "core", "view", "optionDefaultUserAgent", params).await
 }
 
 /**
  * Gets the TTL (in seconds) of successful DNS queries.
 */
-pub fn option_dns_ttl_successful_queries(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_dns_ttl_successful_queries(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "core",
-        "view",
-        "optionDnsTtlSuccessfulQueries",
-        params,
-    )
+    super::call(service, "core", "view", "optionDnsTtlSuccessfulQueries", params).await
 }
 
-pub fn option_http_state(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_http_state(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "optionHttpState", params)
+    super::call(service, "core", "view", "optionHttpState", params).await
 }
 
-pub fn option_proxy_chain_name(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_proxy_chain_name(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "optionProxyChainName", params)
+    super::call(service, "core", "view", "optionProxyChainName", params).await
 }
 
-pub fn option_proxy_chain_password(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_proxy_chain_password(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "optionProxyChainPassword", params)
+    super::call(service, "core", "view", "optionProxyChainPassword", params).await
 }
 
-pub fn option_proxy_chain_port(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_proxy_chain_port(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "optionProxyChainPort", params)
+    super::call(service, "core", "view", "optionProxyChainPort", params).await
 }
 
-pub fn option_proxy_chain_realm(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_proxy_chain_realm(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "optionProxyChainRealm", params)
+    super::call(service, "core", "view", "optionProxyChainRealm", params).await
 }
 
-pub fn option_proxy_chain_user_name(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_proxy_chain_user_name(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "optionProxyChainUserName", params)
+    super::call(service, "core", "view", "optionProxyChainUserName", params).await
 }
 
 /**
  * Gets the connection time out, in seconds.
 */
-pub fn option_timeout_in_secs(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_timeout_in_secs(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "optionTimeoutInSecs", params)
+    super::call(service, "core", "view", "optionTimeoutInSecs", params).await
 }
 
-pub fn option_http_state_enabled(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_http_state_enabled(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "optionHttpStateEnabled", params)
+    super::call(service, "core", "view", "optionHttpStateEnabled", params).await
 }
 
-pub fn option_proxy_chain_prompt(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_proxy_chain_prompt(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "optionProxyChainPrompt", params)
+    super::call(service, "core", "view", "optionProxyChainPrompt", params).await
 }
 
-pub fn option_single_cookie_request_header(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_single_cookie_request_header(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "core",
-        "view",
-        "optionSingleCookieRequestHeader",
-        params,
-    )
+    super::call(service, "core", "view", "optionSingleCookieRequestHeader", params).await
 }
 
-pub fn option_use_proxy_chain(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_use_proxy_chain(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "optionUseProxyChain", params)
+    super::call(service, "core", "view", "optionUseProxyChain", params).await
 }
 
-pub fn option_use_proxy_chain_auth(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_use_proxy_chain_auth(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "view", "optionUseProxyChainAuth", params)
+    super::call(service, "core", "view", "optionUseProxyChainAuth", params).await
+}
+
+/**
+ * Gets whether or not the SOCKS proxy should be used.
+*/
+pub async fn option_use_socks_proxy(service: &ZapService) -> Result<Value, ZapApiError> {
+    let params = HashMap::new();
+    super::call(service, "core", "view", "optionUseSocksProxy", params).await
 }
 
 /**
  * Convenient and simple action to access a URL, optionally following redirections. Returns the request sent and response received and followed redirections, if any. Other actions are available which offer more control on what is sent, like, 'sendRequest' or 'sendHarRequest'.
 */
-pub fn access_url(
-    service: &ZapService,
-    url: String,
-    followredirects: String,
-) -> Result<Value, ZapApiError> {
+pub async fn access_url(service: &ZapService, url: &str, followredirects: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("url".to_string(), url);
-    params.insert("followRedirects".to_string(), followredirects);
-    super::call(service, "core", "action", "accessUrl", params)
+    params.insert("url".to_string(), url.to_string());
+    params.insert("followRedirects".to_string(), followredirects.to_string());
+    super::call(service, "core", "action", "accessUrl", params).await
 }
 
 /**
  * Shuts down ZAP
 */
-pub fn shutdown(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn shutdown(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "action", "shutdown", params)
+    super::call(service, "core", "action", "shutdown", params).await
 }
 
 /**
  * Creates a new session, optionally overwriting existing files. If a relative path is specified it will be resolved against the "session" directory in ZAP "home" dir.
 */
-pub fn new_session(
-    service: &ZapService,
-    name: String,
-    overwrite: String,
-) -> Result<Value, ZapApiError> {
+pub async fn new_session(service: &ZapService, name: &str, overwrite: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("name".to_string(), name);
-    params.insert("overwrite".to_string(), overwrite);
-    super::call(service, "core", "action", "newSession", params)
+    params.insert("name".to_string(), name.to_string());
+    params.insert("overwrite".to_string(), overwrite.to_string());
+    super::call(service, "core", "action", "newSession", params).await
 }
 
 /**
  * Loads the session with the given name. If a relative path is specified it will be resolved against the "session" directory in ZAP "home" dir.
 */
-pub fn load_session(service: &ZapService, name: String) -> Result<Value, ZapApiError> {
+pub async fn load_session(service: &ZapService, name: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("name".to_string(), name);
-    super::call(service, "core", "action", "loadSession", params)
+    params.insert("name".to_string(), name.to_string());
+    super::call(service, "core", "action", "loadSession", params).await
 }
 
 /**
- * Saves the session with the name supplied, optionally overwriting existing files. If a relative path is specified it will be resolved against the "session" directory in ZAP "home" dir.
+ * Saves the session.
 */
-pub fn save_session(
-    service: &ZapService,
-    name: String,
-    overwrite: String,
-) -> Result<Value, ZapApiError> {
+pub async fn save_session(service: &ZapService, name: &str, overwrite: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("name".to_string(), name);
-    params.insert("overwrite".to_string(), overwrite);
-    super::call(service, "core", "action", "saveSession", params)
+    params.insert("name".to_string(), name.to_string());
+    params.insert("overwrite".to_string(), overwrite.to_string());
+    super::call(service, "core", "action", "saveSession", params).await
 }
 
 /**
  * Snapshots the session, optionally with the given name, and overwriting existing files. If no name is specified the name of the current session with a timestamp appended is used. If a relative path is specified it will be resolved against the "session" directory in ZAP "home" dir.
 */
-pub fn snapshot_session(
-    service: &ZapService,
-    name: String,
-    overwrite: String,
-) -> Result<Value, ZapApiError> {
+pub async fn snapshot_session(service: &ZapService, name: &str, overwrite: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("name".to_string(), name);
-    params.insert("overwrite".to_string(), overwrite);
-    super::call(service, "core", "action", "snapshotSession", params)
+    params.insert("name".to_string(), name.to_string());
+    params.insert("overwrite".to_string(), overwrite.to_string());
+    super::call(service, "core", "action", "snapshotSession", params).await
 }
 
 /**
  * Clears the regexes of URLs excluded from the local proxies.
 */
-pub fn clear_excluded_from_proxy(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn clear_excluded_from_proxy(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "action", "clearExcludedFromProxy", params)
+    super::call(service, "core", "action", "clearExcludedFromProxy", params).await
 }
 
 /**
  * Adds a regex of URLs that should be excluded from the local proxies.
 */
-pub fn exclude_from_proxy(service: &ZapService, regex: String) -> Result<Value, ZapApiError> {
+pub async fn exclude_from_proxy(service: &ZapService, regex: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("regex".to_string(), regex);
-    super::call(service, "core", "action", "excludeFromProxy", params)
+    params.insert("regex".to_string(), regex.to_string());
+    super::call(service, "core", "action", "excludeFromProxy", params).await
 }
 
-pub fn set_home_directory(service: &ZapService, dir: String) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_home_directory(service: &ZapService, dir: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("dir".to_string(), dir);
-    super::call(service, "core", "action", "setHomeDirectory", params)
+    params.insert("dir".to_string(), dir.to_string());
+    super::call(service, "core", "action", "setHomeDirectory", params).await
 }
 
 /**
  * Sets the mode, which may be one of [safe, protect, standard, attack]
 */
-pub fn set_mode(service: &ZapService, mode: String) -> Result<Value, ZapApiError> {
+pub async fn set_mode(service: &ZapService, mode: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("mode".to_string(), mode);
-    super::call(service, "core", "action", "setMode", params)
+    params.insert("mode".to_string(), mode.to_string());
+    super::call(service, "core", "action", "setMode", params).await
 }
 
 /**
  * Generates a new Root CA certificate for the local proxies.
 */
-pub fn generate_root_ca(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn generate_root_ca(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "action", "generateRootCA", params)
+    super::call(service, "core", "action", "generateRootCA", params).await
 }
 
 /**
  * Sends the HTTP request, optionally following redirections. Returns the request sent and response received and followed redirections, if any. The Mode is enforced when sending the request (and following redirections), custom manual requests are not allowed in 'Safe' mode nor in 'Protected' mode if out of scope.
 */
-pub fn send_request(
-    service: &ZapService,
-    request: String,
-    followredirects: String,
-) -> Result<Value, ZapApiError> {
+pub async fn send_request(service: &ZapService, request: &str, followredirects: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("request".to_string(), request);
-    params.insert("followRedirects".to_string(), followredirects);
-    super::call(service, "core", "action", "sendRequest", params)
-}
-
-pub fn run_garbage_collection(service: &ZapService) -> Result<Value, ZapApiError> {
-    let params = HashMap::new();
-    super::call(service, "core", "action", "runGarbageCollection", params)
+    params.insert("request".to_string(), request.to_string());
+    params.insert("followRedirects".to_string(), followredirects.to_string());
+    super::call(service, "core", "action", "sendRequest", params).await
 }
 
 /**
- * Deletes the site node found in the Sites Tree on the basis of the URL, HTTP method, and post data (if applicable and specified).
+ * 
 */
-pub fn delete_site_node(
-    service: &ZapService,
-    url: String,
-    method: String,
-    postdata: String,
-) -> Result<Value, ZapApiError> {
+pub async fn run_garbage_collection(service: &ZapService) -> Result<Value, ZapApiError> {
+    let params = HashMap::new();
+    super::call(service, "core", "action", "runGarbageCollection", params).await
+}
+
+/**
+ * Deletes the site node found in the Sites Tree on the basis of the URL, HTTP method, and post data (if applicable and specified). 
+*/
+pub async fn delete_site_node(service: &ZapService, url: &str, method: &str, postdata: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("url".to_string(), url);
-    params.insert("method".to_string(), method);
-    params.insert("postData".to_string(), postdata);
-    super::call(service, "core", "action", "deleteSiteNode", params)
+    params.insert("url".to_string(), url.to_string());
+    params.insert("method".to_string(), method.to_string());
+    params.insert("postData".to_string(), postdata.to_string());
+    super::call(service, "core", "action", "deleteSiteNode", params).await
 }
 
 /**
  * Adds a domain to be excluded from the outgoing proxy, using the specified value. Optionally sets if the new entry is enabled (default, true) and whether or not the new value is specified as a regex (default, false).
 */
-pub fn add_proxy_chain_excluded_domain(
-    service: &ZapService,
-    value: String,
-    isregex: String,
-    isenabled: String,
-) -> Result<Value, ZapApiError> {
+pub async fn add_proxy_chain_excluded_domain(service: &ZapService, value: &str, isregex: &str, isenabled: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("value".to_string(), value);
-    params.insert("isRegex".to_string(), isregex);
-    params.insert("isEnabled".to_string(), isenabled);
-    super::call(
-        service,
-        "core",
-        "action",
-        "addProxyChainExcludedDomain",
-        params,
-    )
+    params.insert("value".to_string(), value.to_string());
+    params.insert("isRegex".to_string(), isregex.to_string());
+    params.insert("isEnabled".to_string(), isenabled.to_string());
+    super::call(service, "core", "action", "addProxyChainExcludedDomain", params).await
 }
 
 /**
  * Modifies a domain excluded from the outgoing proxy. Allows to modify the value, if enabled or if a regex. The domain is selected with its index, which can be obtained with the view proxyChainExcludedDomains.
 */
-pub fn modify_proxy_chain_excluded_domain(
-    service: &ZapService,
-    idx: String,
-    value: String,
-    isregex: String,
-    isenabled: String,
-) -> Result<Value, ZapApiError> {
+pub async fn modify_proxy_chain_excluded_domain(service: &ZapService, idx: &str, value: &str, isregex: &str, isenabled: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("idx".to_string(), idx);
-    params.insert("value".to_string(), value);
-    params.insert("isRegex".to_string(), isregex);
-    params.insert("isEnabled".to_string(), isenabled);
-    super::call(
-        service,
-        "core",
-        "action",
-        "modifyProxyChainExcludedDomain",
-        params,
-    )
+    params.insert("idx".to_string(), idx.to_string());
+    params.insert("value".to_string(), value.to_string());
+    params.insert("isRegex".to_string(), isregex.to_string());
+    params.insert("isEnabled".to_string(), isenabled.to_string());
+    super::call(service, "core", "action", "modifyProxyChainExcludedDomain", params).await
 }
 
 /**
  * Removes a domain excluded from the outgoing proxy, with the given index. The index can be obtained with the view proxyChainExcludedDomains.
 */
-pub fn remove_proxy_chain_excluded_domain(
-    service: &ZapService,
-    idx: String,
-) -> Result<Value, ZapApiError> {
+pub async fn remove_proxy_chain_excluded_domain(service: &ZapService, idx: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("idx".to_string(), idx);
-    super::call(
-        service,
-        "core",
-        "action",
-        "removeProxyChainExcludedDomain",
-        params,
-    )
+    params.insert("idx".to_string(), idx.to_string());
+    super::call(service, "core", "action", "removeProxyChainExcludedDomain", params).await
 }
 
 /**
  * Enables all domains excluded from the outgoing proxy.
 */
-pub fn enable_all_proxy_chain_excluded_domains(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn enable_all_proxy_chain_excluded_domains(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "core",
-        "action",
-        "enableAllProxyChainExcludedDomains",
-        params,
-    )
+    super::call(service, "core", "action", "enableAllProxyChainExcludedDomains", params).await
 }
 
 /**
  * Disables all domains excluded from the outgoing proxy.
 */
-pub fn disable_all_proxy_chain_excluded_domains(
-    service: &ZapService,
-) -> Result<Value, ZapApiError> {
+pub async fn disable_all_proxy_chain_excluded_domains(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "core",
-        "action",
-        "disableAllProxyChainExcludedDomains",
-        params,
-    )
+    super::call(service, "core", "action", "disableAllProxyChainExcludedDomains", params).await
 }
 
 /**
  * Sets the maximum number of alert instances to include in a report. A value of zero is treated as unlimited.
 */
-pub fn set_option_maximum_alert_instances(
-    service: &ZapService,
-    numberofinstances: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_option_maximum_alert_instances(service: &ZapService, numberofinstances: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("numberOfInstances".to_string(), numberofinstances);
-    super::call(
-        service,
-        "core",
-        "action",
-        "setOptionMaximumAlertInstances",
-        params,
-    )
+    params.insert("numberOfInstances".to_string(), numberofinstances.to_string());
+    super::call(service, "core", "action", "setOptionMaximumAlertInstances", params).await
 }
 
 /**
  * Sets whether or not related alerts will be merged in any reports generated.
 */
-pub fn set_option_merge_related_alerts(
-    service: &ZapService,
-    enabled: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_option_merge_related_alerts(service: &ZapService, enabled: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("enabled".to_string(), enabled);
-    super::call(
-        service,
-        "core",
-        "action",
-        "setOptionMergeRelatedAlerts",
-        params,
-    )
+    params.insert("enabled".to_string(), enabled.to_string());
+    super::call(service, "core", "action", "setOptionMergeRelatedAlerts", params).await
 }
 
 /**
  * Sets (or clears, if empty) the path to the file with alert overrides.
 */
-pub fn set_option_alert_overrides_file_path(
-    service: &ZapService,
-    filepath: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_option_alert_overrides_file_path(service: &ZapService, filepath: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("filePath".to_string(), filepath);
-    super::call(
-        service,
-        "core",
-        "action",
-        "setOptionAlertOverridesFilePath",
-        params,
-    )
+    params.insert("filePath".to_string(), filepath.to_string());
+    super::call(service, "core", "action", "setOptionAlertOverridesFilePath", params).await
 }
 
 /**
  * Enables use of a PKCS12 client certificate for the certificate with the given file system path, password, and optional index.
 */
-pub fn enable_pkcs_12_client_certificate(
-    service: &ZapService,
-    filepath: String,
-    password: String,
-    index: String,
-) -> Result<Value, ZapApiError> {
+pub async fn enable_pkcs_12_client_certificate(service: &ZapService, filepath: &str, password: &str, index: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("filePath".to_string(), filepath);
-    params.insert("password".to_string(), password);
-    params.insert("index".to_string(), index);
-    super::call(
-        service,
-        "core",
-        "action",
-        "enablePKCS12ClientCertificate",
-        params,
-    )
+    params.insert("filePath".to_string(), filepath.to_string());
+    params.insert("password".to_string(), password.to_string());
+    params.insert("index".to_string(), index.to_string());
+    super::call(service, "core", "action", "enablePKCS12ClientCertificate", params).await
 }
 
 /**
  * Disables the option for use of client certificates.
 */
-pub fn disable_client_certificate(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn disable_client_certificate(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "core",
-        "action",
-        "disableClientCertificate",
-        params,
-    )
+    super::call(service, "core", "action", "disableClientCertificate", params).await
 }
 
 /**
  * Deletes all alerts of the current session.
- * Deprecated Use the API endpoint with the same name in the 'alert' component instead.
 */
-pub fn delete_all_alerts(service: &ZapService) -> Result<Value, ZapApiError> {
+#[deprecated(note="Use the API endpoint with the same name in the 'alert' component instead.")]
+pub async fn delete_all_alerts(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "action", "deleteAllAlerts", params)
+    super::call(service, "core", "action", "deleteAllAlerts", params).await
 }
 
 /**
- * Deletes the alert with the given ID.
- * Deprecated Use the API endpoint with the same name in the 'alert' component instead.
+ * Deletes the alert with the given ID. 
 */
-pub fn delete_alert(service: &ZapService, id: String) -> Result<Value, ZapApiError> {
+#[deprecated(note="Use the API endpoint with the same name in the 'alert' component instead.")]
+pub async fn delete_alert(service: &ZapService, id: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("id".to_string(), id);
-    super::call(service, "core", "action", "deleteAlert", params)
+    params.insert("id".to_string(), id.to_string());
+    super::call(service, "core", "action", "deleteAlert", params).await
 }
 
 /**
  * Sets the user agent that ZAP should use when creating HTTP messages (for example, spider messages or CONNECT requests to outgoing proxy).
 */
-pub fn set_option_default_user_agent(
-    service: &ZapService,
-    string: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_option_default_user_agent(service: &ZapService, string: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("String".to_string(), string);
-    super::call(
-        service,
-        "core",
-        "action",
-        "setOptionDefaultUserAgent",
-        params,
-    )
+    params.insert("String".to_string(), string.to_string());
+    super::call(service, "core", "action", "setOptionDefaultUserAgent", params).await
 }
 
-pub fn set_option_proxy_chain_name(
-    service: &ZapService,
-    string: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_proxy_chain_name(service: &ZapService, string: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("String".to_string(), string);
-    super::call(service, "core", "action", "setOptionProxyChainName", params)
+    params.insert("String".to_string(), string.to_string());
+    super::call(service, "core", "action", "setOptionProxyChainName", params).await
 }
 
-pub fn set_option_proxy_chain_password(
-    service: &ZapService,
-    string: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_proxy_chain_password(service: &ZapService, string: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("String".to_string(), string);
-    super::call(
-        service,
-        "core",
-        "action",
-        "setOptionProxyChainPassword",
-        params,
-    )
+    params.insert("String".to_string(), string.to_string());
+    super::call(service, "core", "action", "setOptionProxyChainPassword", params).await
 }
 
-pub fn set_option_proxy_chain_realm(
-    service: &ZapService,
-    string: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_proxy_chain_realm(service: &ZapService, string: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("String".to_string(), string);
-    super::call(
-        service,
-        "core",
-        "action",
-        "setOptionProxyChainRealm",
-        params,
-    )
+    params.insert("String".to_string(), string.to_string());
+    super::call(service, "core", "action", "setOptionProxyChainRealm", params).await
 }
 
 /**
  * Use actions [add|modify|remove]ProxyChainExcludedDomain instead.
- * Deprecated Option no longer in effective use.
 */
-pub fn set_option_proxy_chain_skip_name(
-    service: &ZapService,
-    string: String,
-) -> Result<Value, ZapApiError> {
+#[deprecated(note="Option no longer in effective use.")]
+pub async fn set_option_proxy_chain_skip_name(service: &ZapService, string: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("String".to_string(), string);
-    super::call(
-        service,
-        "core",
-        "action",
-        "setOptionProxyChainSkipName",
-        params,
-    )
+    params.insert("String".to_string(), string.to_string());
+    super::call(service, "core", "action", "setOptionProxyChainSkipName", params).await
 }
 
-pub fn set_option_proxy_chain_user_name(
-    service: &ZapService,
-    string: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_proxy_chain_user_name(service: &ZapService, string: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("String".to_string(), string);
-    super::call(
-        service,
-        "core",
-        "action",
-        "setOptionProxyChainUserName",
-        params,
-    )
+    params.insert("String".to_string(), string.to_string());
+    super::call(service, "core", "action", "setOptionProxyChainUserName", params).await
 }
 
 /**
  * Sets the TTL (in seconds) of successful DNS queries (applies after ZAP restart).
 */
-pub fn set_option_dns_ttl_successful_queries(
-    service: &ZapService,
-    integer: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_option_dns_ttl_successful_queries(service: &ZapService, integer: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Integer".to_string(), integer);
-    super::call(
-        service,
-        "core",
-        "action",
-        "setOptionDnsTtlSuccessfulQueries",
-        params,
-    )
+    params.insert("Integer".to_string(), integer.to_string());
+    super::call(service, "core", "action", "setOptionDnsTtlSuccessfulQueries", params).await
 }
 
-pub fn set_option_http_state_enabled(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_http_state_enabled(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "core",
-        "action",
-        "setOptionHttpStateEnabled",
-        params,
-    )
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "core", "action", "setOptionHttpStateEnabled", params).await
 }
 
-pub fn set_option_proxy_chain_port(
-    service: &ZapService,
-    integer: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_proxy_chain_port(service: &ZapService, integer: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Integer".to_string(), integer);
-    super::call(service, "core", "action", "setOptionProxyChainPort", params)
+    params.insert("Integer".to_string(), integer.to_string());
+    super::call(service, "core", "action", "setOptionProxyChainPort", params).await
 }
 
-pub fn set_option_proxy_chain_prompt(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_proxy_chain_prompt(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "core",
-        "action",
-        "setOptionProxyChainPrompt",
-        params,
-    )
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "core", "action", "setOptionProxyChainPrompt", params).await
 }
 
-pub fn set_option_single_cookie_request_header(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_single_cookie_request_header(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "core",
-        "action",
-        "setOptionSingleCookieRequestHeader",
-        params,
-    )
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "core", "action", "setOptionSingleCookieRequestHeader", params).await
 }
 
 /**
  * Sets the connection time out, in seconds.
 */
-pub fn set_option_timeout_in_secs(
-    service: &ZapService,
-    integer: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_option_timeout_in_secs(service: &ZapService, integer: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Integer".to_string(), integer);
-    super::call(service, "core", "action", "setOptionTimeoutInSecs", params)
+    params.insert("Integer".to_string(), integer.to_string());
+    super::call(service, "core", "action", "setOptionTimeoutInSecs", params).await
 }
 
 /**
  * Sets whether or not the outgoing proxy should be used. The address/hostname of the outgoing proxy must be set to enable this option.
 */
-pub fn set_option_use_proxy_chain(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_option_use_proxy_chain(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(service, "core", "action", "setOptionUseProxyChain", params)
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "core", "action", "setOptionUseProxyChain", params).await
 }
 
-pub fn set_option_use_proxy_chain_auth(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_use_proxy_chain_auth(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "core",
-        "action",
-        "setOptionUseProxyChainAuth",
-        params,
-    )
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "core", "action", "setOptionUseProxyChainAuth", params).await
 }
 
-pub fn proxy_pac(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * Sets whether or not the SOCKS proxy should be used.
+*/
+pub async fn set_option_use_socks_proxy(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "core", "action", "setOptionUseSocksProxy", params).await
+}
+
+/**
+ * 
+*/
+pub async fn proxy_pac(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "other", "proxy.pac", params)
+    super::call(service, "core", "other", "proxy.pac", params).await
 }
 
 /**
  * Gets the Root CA certificate used by the local proxies.
 */
-pub fn rootcert(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn rootcert(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "other", "rootcert", params)
+    super::call(service, "core", "other", "rootcert", params).await
 }
 
-pub fn setproxy(service: &ZapService, proxy: String) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn setproxy(service: &ZapService, proxy: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("proxy".to_string(), proxy);
-    super::call(service, "core", "other", "setproxy", params)
+    params.insert("proxy".to_string(), proxy.to_string());
+    super::call(service, "core", "other", "setproxy", params).await
 }
 
 /**
  * Generates a report in XML format
 */
-pub fn xmlreport(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn xmlreport(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "other", "xmlreport", params)
+    super::call(service, "core", "other", "xmlreport", params).await
 }
 
 /**
  * Generates a report in HTML format
 */
-pub fn htmlreport(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn htmlreport(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "other", "htmlreport", params)
+    super::call(service, "core", "other", "htmlreport", params).await
 }
 
 /**
  * Generates a report in JSON format
 */
-pub fn jsonreport(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn jsonreport(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "other", "jsonreport", params)
+    super::call(service, "core", "other", "jsonreport", params).await
 }
 
 /**
  * Generates a report in Markdown format
 */
-pub fn mdreport(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn mdreport(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "core", "other", "mdreport", params)
+    super::call(service, "core", "other", "mdreport", params).await
 }
 
 /**
  * Gets the message with the given ID in HAR format
 */
-pub fn message_har(service: &ZapService, id: String) -> Result<Value, ZapApiError> {
+pub async fn message_har(service: &ZapService, id: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("id".to_string(), id);
-    super::call(service, "core", "other", "messageHar", params)
+    params.insert("id".to_string(), id.to_string());
+    super::call(service, "core", "other", "messageHar", params).await
 }
 
 /**
  * Gets the HTTP messages sent through/by ZAP, in HAR format, optionally filtered by URL and paginated with 'start' position and 'count' of messages
 */
-pub fn messages_har(
-    service: &ZapService,
-    baseurl: String,
-    start: String,
-    count: String,
-) -> Result<Value, ZapApiError> {
+pub async fn messages_har(service: &ZapService, baseurl: &str, start: &str, count: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("baseurl".to_string(), baseurl);
-    params.insert("start".to_string(), start);
-    params.insert("count".to_string(), count);
-    super::call(service, "core", "other", "messagesHar", params)
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    params.insert("start".to_string(), start.to_string());
+    params.insert("count".to_string(), count.to_string());
+    super::call(service, "core", "other", "messagesHar", params).await
 }
 
 /**
  * Gets the HTTP messages with the given IDs, in HAR format.
 */
-pub fn messages_har_by_id(service: &ZapService, ids: String) -> Result<Value, ZapApiError> {
+pub async fn messages_har_by_id(service: &ZapService, ids: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("ids".to_string(), ids);
-    super::call(service, "core", "other", "messagesHarById", params)
+    params.insert("ids".to_string(), ids.to_string());
+    super::call(service, "core", "other", "messagesHarById", params).await
 }
 
 /**
  * Sends the first HAR request entry, optionally following redirections. Returns, in HAR format, the request sent and response received and followed redirections, if any. The Mode is enforced when sending the request (and following redirections), custom manual requests are not allowed in 'Safe' mode nor in 'Protected' mode if out of scope.
 */
-pub fn send_har_request(
-    service: &ZapService,
-    request: String,
-    followredirects: String,
-) -> Result<Value, ZapApiError> {
+pub async fn send_har_request(service: &ZapService, request: &str, followredirects: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("request".to_string(), request);
-    params.insert("followRedirects".to_string(), followredirects);
-    super::call(service, "core", "other", "sendHarRequest", params)
+    params.insert("request".to_string(), request.to_string());
+    params.insert("followRedirects".to_string(), followredirects.to_string());
+    super::call(service, "core", "other", "sendHarRequest", params).await
 }
+

--- a/src/forced_user.rs
+++ b/src/forced_user.rs
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 the ZAP development team
+ * Copyright 2020 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
  * limitations under the License.
  */
 
+
 use super::ZapApiError;
 use super::ZapService;
 use serde_json::Value;
 use std::collections::HashMap;
+
 
 /**
  * This file was automatically generated.
@@ -28,54 +30,36 @@ use std::collections::HashMap;
 /**
  * Returns 'true' if 'forced user' mode is enabled, 'false' otherwise
 */
-pub fn is_forced_user_mode_enabled(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn is_forced_user_mode_enabled(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "forcedUser",
-        "view",
-        "isForcedUserModeEnabled",
-        params,
-    )
+    super::call(service, "forcedUser", "view", "isForcedUserModeEnabled", params).await
 }
 
 /**
  * Gets the user (ID) set as 'forced user' for the given context (ID)
 */
-pub fn get_forced_user(service: &ZapService, contextid: String) -> Result<Value, ZapApiError> {
+pub async fn get_forced_user(service: &ZapService, contextid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    super::call(service, "forcedUser", "view", "getForcedUser", params)
+    params.insert("contextId".to_string(), contextid.to_string());
+    super::call(service, "forcedUser", "view", "getForcedUser", params).await
 }
 
 /**
  * Sets the user (ID) that should be used in 'forced user' mode for the given context (ID)
 */
-pub fn set_forced_user(
-    service: &ZapService,
-    contextid: String,
-    userid: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_forced_user(service: &ZapService, contextid: &str, userid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    params.insert("userId".to_string(), userid);
-    super::call(service, "forcedUser", "action", "setForcedUser", params)
+    params.insert("contextId".to_string(), contextid.to_string());
+    params.insert("userId".to_string(), userid.to_string());
+    super::call(service, "forcedUser", "action", "setForcedUser", params).await
 }
 
 /**
  * Sets if 'forced user' mode should be enabled or not
 */
-pub fn set_forced_user_mode_enabled(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_forced_user_mode_enabled(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("boolean".to_string(), boolean);
-    super::call(
-        service,
-        "forcedUser",
-        "action",
-        "setForcedUserModeEnabled",
-        params,
-    )
+    params.insert("boolean".to_string(), boolean.to_string());
+    super::call(service, "forcedUser", "action", "setForcedUserModeEnabled", params).await
 }
+

--- a/src/http_sessions.rs
+++ b/src/http_sessions.rs
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 the ZAP development team
+ * Copyright 2020 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
  * limitations under the License.
  */
 
+
 use super::ZapApiError;
 use super::ZapService;
 use serde_json::Value;
 use std::collections::HashMap;
+
 
 /**
  * This file was automatically generated.
@@ -28,250 +30,155 @@ use std::collections::HashMap;
 /**
  * Gets all of the sites that have sessions.
 */
-pub fn sites(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn sites(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "httpSessions", "view", "sites", params)
+    super::call(service, "httpSessions", "view", "sites", params).await
 }
 
 /**
  * Gets the sessions for the given site. Optionally returning just the session with the given name.
 */
-pub fn sessions(service: &ZapService, site: String, session: String) -> Result<Value, ZapApiError> {
+pub async fn sessions(service: &ZapService, site: &str, session: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("site".to_string(), site);
-    params.insert("session".to_string(), session);
-    super::call(service, "httpSessions", "view", "sessions", params)
+    params.insert("site".to_string(), site.to_string());
+    params.insert("session".to_string(), session.to_string());
+    super::call(service, "httpSessions", "view", "sessions", params).await
 }
 
 /**
  * Gets the name of the active session for the given site.
 */
-pub fn active_session(service: &ZapService, site: String) -> Result<Value, ZapApiError> {
+pub async fn active_session(service: &ZapService, site: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("site".to_string(), site);
-    super::call(service, "httpSessions", "view", "activeSession", params)
+    params.insert("site".to_string(), site.to_string());
+    super::call(service, "httpSessions", "view", "activeSession", params).await
 }
 
 /**
  * Gets the names of the session tokens for the given site.
 */
-pub fn session_tokens(service: &ZapService, site: String) -> Result<Value, ZapApiError> {
+pub async fn session_tokens(service: &ZapService, site: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("site".to_string(), site);
-    super::call(service, "httpSessions", "view", "sessionTokens", params)
+    params.insert("site".to_string(), site.to_string());
+    super::call(service, "httpSessions", "view", "sessionTokens", params).await
 }
 
 /**
  * Gets the default session tokens.
 */
-pub fn default_session_tokens(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn default_session_tokens(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "httpSessions",
-        "view",
-        "defaultSessionTokens",
-        params,
-    )
+    super::call(service, "httpSessions", "view", "defaultSessionTokens", params).await
 }
 
 /**
  * Creates an empty session for the given site. Optionally with the given name.
 */
-pub fn create_empty_session(
-    service: &ZapService,
-    site: String,
-    session: String,
-) -> Result<Value, ZapApiError> {
+pub async fn create_empty_session(service: &ZapService, site: &str, session: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("site".to_string(), site);
-    params.insert("session".to_string(), session);
-    super::call(
-        service,
-        "httpSessions",
-        "action",
-        "createEmptySession",
-        params,
-    )
+    params.insert("site".to_string(), site.to_string());
+    params.insert("session".to_string(), session.to_string());
+    super::call(service, "httpSessions", "action", "createEmptySession", params).await
 }
 
 /**
  * Removes the session from the given site.
 */
-pub fn remove_session(
-    service: &ZapService,
-    site: String,
-    session: String,
-) -> Result<Value, ZapApiError> {
+pub async fn remove_session(service: &ZapService, site: &str, session: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("site".to_string(), site);
-    params.insert("session".to_string(), session);
-    super::call(service, "httpSessions", "action", "removeSession", params)
+    params.insert("site".to_string(), site.to_string());
+    params.insert("session".to_string(), session.to_string());
+    super::call(service, "httpSessions", "action", "removeSession", params).await
 }
 
 /**
  * Sets the given session as active for the given site.
 */
-pub fn set_active_session(
-    service: &ZapService,
-    site: String,
-    session: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_active_session(service: &ZapService, site: &str, session: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("site".to_string(), site);
-    params.insert("session".to_string(), session);
-    super::call(
-        service,
-        "httpSessions",
-        "action",
-        "setActiveSession",
-        params,
-    )
+    params.insert("site".to_string(), site.to_string());
+    params.insert("session".to_string(), session.to_string());
+    super::call(service, "httpSessions", "action", "setActiveSession", params).await
 }
 
 /**
  * Unsets the active session of the given site.
 */
-pub fn unset_active_session(service: &ZapService, site: String) -> Result<Value, ZapApiError> {
+pub async fn unset_active_session(service: &ZapService, site: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("site".to_string(), site);
-    super::call(
-        service,
-        "httpSessions",
-        "action",
-        "unsetActiveSession",
-        params,
-    )
+    params.insert("site".to_string(), site.to_string());
+    super::call(service, "httpSessions", "action", "unsetActiveSession", params).await
 }
 
 /**
  * Adds the session token to the given site.
 */
-pub fn add_session_token(
-    service: &ZapService,
-    site: String,
-    sessiontoken: String,
-) -> Result<Value, ZapApiError> {
+pub async fn add_session_token(service: &ZapService, site: &str, sessiontoken: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("site".to_string(), site);
-    params.insert("sessionToken".to_string(), sessiontoken);
-    super::call(service, "httpSessions", "action", "addSessionToken", params)
+    params.insert("site".to_string(), site.to_string());
+    params.insert("sessionToken".to_string(), sessiontoken.to_string());
+    super::call(service, "httpSessions", "action", "addSessionToken", params).await
 }
 
 /**
  * Removes the session token from the given site.
 */
-pub fn remove_session_token(
-    service: &ZapService,
-    site: String,
-    sessiontoken: String,
-) -> Result<Value, ZapApiError> {
+pub async fn remove_session_token(service: &ZapService, site: &str, sessiontoken: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("site".to_string(), site);
-    params.insert("sessionToken".to_string(), sessiontoken);
-    super::call(
-        service,
-        "httpSessions",
-        "action",
-        "removeSessionToken",
-        params,
-    )
+    params.insert("site".to_string(), site.to_string());
+    params.insert("sessionToken".to_string(), sessiontoken.to_string());
+    super::call(service, "httpSessions", "action", "removeSessionToken", params).await
 }
 
 /**
  * Sets the value of the session token of the given session for the given site.
 */
-pub fn set_session_token_value(
-    service: &ZapService,
-    site: String,
-    session: String,
-    sessiontoken: String,
-    tokenvalue: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_session_token_value(service: &ZapService, site: &str, session: &str, sessiontoken: &str, tokenvalue: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("site".to_string(), site);
-    params.insert("session".to_string(), session);
-    params.insert("sessionToken".to_string(), sessiontoken);
-    params.insert("tokenValue".to_string(), tokenvalue);
-    super::call(
-        service,
-        "httpSessions",
-        "action",
-        "setSessionTokenValue",
-        params,
-    )
+    params.insert("site".to_string(), site.to_string());
+    params.insert("session".to_string(), session.to_string());
+    params.insert("sessionToken".to_string(), sessiontoken.to_string());
+    params.insert("tokenValue".to_string(), tokenvalue.to_string());
+    super::call(service, "httpSessions", "action", "setSessionTokenValue", params).await
 }
 
 /**
  * Renames the session of the given site.
 */
-pub fn rename_session(
-    service: &ZapService,
-    site: String,
-    oldsessionname: String,
-    newsessionname: String,
-) -> Result<Value, ZapApiError> {
+pub async fn rename_session(service: &ZapService, site: &str, oldsessionname: &str, newsessionname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("site".to_string(), site);
-    params.insert("oldSessionName".to_string(), oldsessionname);
-    params.insert("newSessionName".to_string(), newsessionname);
-    super::call(service, "httpSessions", "action", "renameSession", params)
+    params.insert("site".to_string(), site.to_string());
+    params.insert("oldSessionName".to_string(), oldsessionname.to_string());
+    params.insert("newSessionName".to_string(), newsessionname.to_string());
+    super::call(service, "httpSessions", "action", "renameSession", params).await
 }
 
 /**
  * Adds a default session token with the given name and enabled state.
 */
-pub fn add_default_session_token(
-    service: &ZapService,
-    sessiontoken: String,
-    tokenenabled: String,
-) -> Result<Value, ZapApiError> {
+pub async fn add_default_session_token(service: &ZapService, sessiontoken: &str, tokenenabled: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("sessionToken".to_string(), sessiontoken);
-    params.insert("tokenEnabled".to_string(), tokenenabled);
-    super::call(
-        service,
-        "httpSessions",
-        "action",
-        "addDefaultSessionToken",
-        params,
-    )
+    params.insert("sessionToken".to_string(), sessiontoken.to_string());
+    params.insert("tokenEnabled".to_string(), tokenenabled.to_string());
+    super::call(service, "httpSessions", "action", "addDefaultSessionToken", params).await
 }
 
 /**
  * Sets whether or not the default session token with the given name is enabled.
 */
-pub fn set_default_session_token_enabled(
-    service: &ZapService,
-    sessiontoken: String,
-    tokenenabled: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_default_session_token_enabled(service: &ZapService, sessiontoken: &str, tokenenabled: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("sessionToken".to_string(), sessiontoken);
-    params.insert("tokenEnabled".to_string(), tokenenabled);
-    super::call(
-        service,
-        "httpSessions",
-        "action",
-        "setDefaultSessionTokenEnabled",
-        params,
-    )
+    params.insert("sessionToken".to_string(), sessiontoken.to_string());
+    params.insert("tokenEnabled".to_string(), tokenenabled.to_string());
+    super::call(service, "httpSessions", "action", "setDefaultSessionTokenEnabled", params).await
 }
 
 /**
  * Removes the default session token with the given name.
 */
-pub fn remove_default_session_token(
-    service: &ZapService,
-    sessiontoken: String,
-) -> Result<Value, ZapApiError> {
+pub async fn remove_default_session_token(service: &ZapService, sessiontoken: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("sessionToken".to_string(), sessiontoken);
-    super::call(
-        service,
-        "httpSessions",
-        "action",
-        "removeDefaultSessionToken",
-        params,
-    )
+    params.insert("sessionToken".to_string(), sessiontoken.to_string());
+    super::call(service, "httpSessions", "action", "removeDefaultSessionToken", params).await
 }
+

--- a/src/import_log_files.rs
+++ b/src/import_log_files.rs
@@ -23,12 +23,9 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 /**
- * This file was automatically generated.
- */
-/**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn import_zap_log_from_file(
+pub async fn import_zap_log_from_file(
     service: &ZapService,
     filepath: String,
 ) -> Result<Value, ZapApiError> {
@@ -41,12 +38,13 @@ pub fn import_zap_log_from_file(
         "ImportZAPLogFromFile",
         params,
     )
+    .await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn import_mod_security_log_from_file(
+pub async fn import_mod_security_log_from_file(
     service: &ZapService,
     filepath: String,
 ) -> Result<Value, ZapApiError> {
@@ -59,12 +57,13 @@ pub fn import_mod_security_log_from_file(
         "ImportModSecurityLogFromFile",
         params,
     )
+    .await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn import_zap_http_request_response_pair(
+pub async fn import_zap_http_request_response_pair(
     service: &ZapService,
     httprequest: String,
     httpresponse: String,
@@ -79,12 +78,13 @@ pub fn import_zap_http_request_response_pair(
         "ImportZAPHttpRequestResponsePair",
         params,
     )
+    .await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn post_mod_security_audit_event(
+pub async fn post_mod_security_audit_event(
     service: &ZapService,
     auditeventstring: String,
 ) -> Result<Value, ZapApiError> {
@@ -97,12 +97,13 @@ pub fn post_mod_security_audit_event(
         "PostModSecurityAuditEvent",
         params,
     )
+    .await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn other_post_mod_security_audit_event(
+pub async fn other_post_mod_security_audit_event(
     service: &ZapService,
     auditeventstring: String,
 ) -> Result<Value, ZapApiError> {
@@ -115,4 +116,5 @@ pub fn other_post_mod_security_audit_event(
         "OtherPostModSecurityAuditEvent",
         params,
     )
+    .await
 }

--- a/src/importurls.rs
+++ b/src/importurls.rs
@@ -23,15 +23,12 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 /**
- * This file was automatically generated.
- */
-/**
  * Imports URLs (one per line) from the file with the given file system path.
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn importurls(service: &ZapService, filepath: String) -> Result<Value, ZapApiError> {
+pub async fn importurls(service: &ZapService, filepath: String) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
     params.insert("filePath".to_string(), filepath);
-    super::call(service, "importurls", "action", "importurls", params)
+    super::call(service, "importurls", "action", "importurls", params).await
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 the ZAP development team
+ * Copyright 2020 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,8 @@ pub mod import_log_files;
 /// Import URLs
 pub mod importurls;
 
+/// Local Proxies
+pub mod local_proxies;
 
 /// OpenAPI
 pub mod openapi;
@@ -92,6 +94,9 @@ pub mod replacer;
 
 /// Reveal
 pub mod reveal;
+
+/// Rule Config
+pub mod rule_config;
 
 /// Script
 pub mod script;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,6 @@
 
 use serde_json::Value;
 use std::collections::HashMap;
-trait Serialize {}
 
 /// anti-CSRF tokens
 pub mod acsrf;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,51 +16,147 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+//! The Rust implementation to access the OWASP ZAP [API](https://www.zaproxy.org/docs/api/).
+//!
+//! For more information about OWASP ZAP, please visit [zaproxy.org](https://www.zaproxy.org)
+
+#![forbid(unsafe_code, future_incompatible)]
+#![deny(missing_debug_implementations, nonstandard_style, rust_2018_idioms)]
+#![warn(missing_docs)]
+
 use serde_json::Value;
 use std::collections::HashMap;
 trait Serialize {}
 
+/// anti-CSRF tokens
 pub mod acsrf;
+
+/// AJAX Spider
 pub mod ajax_spider;
+
+/// Alert
 pub mod alert;
+
+/// Alert Filter
 pub mod alert_filter;
+
+/// Active Scan
 pub mod ascan;
+
+/// Authentication
 pub mod authentication;
+
+/// Authorization
 pub mod authorization;
+
+/// Auto Update
 pub mod autoupdate;
+
+/// Break
 pub mod brk;
+
+/// Context
 pub mod context;
+
+/// Core
 pub mod core;
+
+/// Forced User
 pub mod forced_user;
+
+/// HTTP Sessions
 pub mod http_sessions;
+
+/// Import Log Files
 pub mod import_log_files;
+
+/// Import URLs
 pub mod importurls;
+
+
+/// OpenAPI
 pub mod openapi;
+
+/// Parameters
 pub mod params;
+
+/// Plug-n-Hack
 pub mod pnh;
+
+/// Passive Scan
 pub mod pscan;
+
+///  Replacer
 pub mod replacer;
+
+/// Reveal
 pub mod reveal;
+
+/// Script
 pub mod script;
+
+/// Search
 pub mod search;
+
+/// Selenium
 pub mod selenium;
+
+/// Session Management
 pub mod session_management;
+
+/// SOAP
 pub mod soap;
+
+/// Spider
 pub mod spider;
+
+/// Stats
 pub mod stats;
+
+/// Users
 pub mod users;
+
+/// WebSockets
 pub mod websocket;
 
+/// ZAP API Service.
+///
+/// # Example
+///
+/// ```
+/// let zap_url = "http://localhost:8080".to_string();
+/// let zap_api_key = "ChangeMe".to_string();
+///
+/// let service = ZapService {
+///     url: zap_url,
+///     api_key: zap_api_key,
+/// };
+/// ```
 #[derive(Debug)]
 pub struct ZapService {
-    pub url: String,     // base url of the ZAP API, eg http://localhost:8080
-    pub api_key: String, // API key used for connecting securely to the API
+    /// Base url of the ZAP API, eg http://localhost:8080
+    pub url: String,
+
+    /// API key used for connecting securely to the API
+    pub api_key: String,
 }
 
+impl ZapService {
+    /// Create a new instance of `ZapService`.
+    pub fn new(url: String, api_key: String) -> Self {
+        Self { url, api_key }
+    }
+}
+
+/// ZAP API Error.
 #[derive(Debug)]
 pub struct ZapApiError {
-    kind: String,    // type of the error
-    message: String, // error message
+    // Type of the error
+    kind: String,
+
+    // Error message
+    message: String,
 }
 
 impl From<reqwest::Error> for ZapApiError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,18 +189,13 @@ pub fn call(
     _params: HashMap<String, String>,
 ) -> Result<Value, ZapApiError> {
     let mut url = [&service.url, "JSON", component, calltype, method, ""].join("/");
-    if _params.keys().len() > 0 {
-        url.push_str("?");
-        for (key, value) in _params {
-            url.push_str(&key);
-            url.push_str("=");
-            url.push_str(&value);
-            url.push_str("&");
-        }
-    }
-
-    let client = reqwest::Client::new();
-    let text = client
+    url.push_str("?");
+    let url_params = params
+        .into_iter()
+        .map(|(key, value)| format!("{}={}", key, value))
+        .collect::<Vec<String>>()
+        .join("&");
+    url.push_str(&url_params);
         .get(&url)
         .header("X-ZAP-API-Key", &*service.api_key)
         .send()?

--- a/src/local_proxies.rs
+++ b/src/local_proxies.rs
@@ -1,0 +1,60 @@
+/* Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 the ZAP development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+use super::ZapApiError;
+use super::ZapService;
+use serde_json::Value;
+use std::collections::HashMap;
+
+
+/**
+ * This file was automatically generated.
+ */
+/**
+ * Gets all of the additional proxies that have been configured.
+*/
+pub async fn additional_proxies(service: &ZapService) -> Result<Value, ZapApiError> {
+    let params = HashMap::new();
+    super::call(service, "localProxies", "view", "additionalProxies", params).await
+}
+
+/**
+ * Adds an new proxy using the details supplied.
+*/
+pub async fn add_additional_proxy(service: &ZapService, address: &str, port: &str, behindnat: &str, alwaysdecodezip: &str, removeunsupportedencodings: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("address".to_string(), address.to_string());
+    params.insert("port".to_string(), port.to_string());
+    params.insert("behindNat".to_string(), behindnat.to_string());
+    params.insert("alwaysDecodeZip".to_string(), alwaysdecodezip.to_string());
+    params.insert("removeUnsupportedEncodings".to_string(), removeunsupportedencodings.to_string());
+    super::call(service, "localProxies", "action", "addAdditionalProxy", params).await
+}
+
+/**
+ * Removes the additional proxy with the specified address and port.
+*/
+pub async fn remove_additional_proxy(service: &ZapService, address: &str, port: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("address".to_string(), address.to_string());
+    params.insert("port".to_string(), port.to_string());
+    super::call(service, "localProxies", "action", "removeAdditionalProxy", params).await
+}
+

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -23,17 +23,14 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 /**
- * This file was automatically generated.
- */
-/**
  * Import an Open API definition from a local file.
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn import_file(service: &ZapService, file: String) -> Result<Value, ZapApiError> {
+pub async fn import_file(service: &ZapService, file: String) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
     params.insert("file".to_string(), file);
-    super::call(service, "openapi", "action", "importFile", params)
+    super::call(service, "openapi", "action", "importFile", params).await
 }
 
 /**
@@ -41,7 +38,7 @@ pub fn import_file(service: &ZapService, file: String) -> Result<Value, ZapApiEr
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn import_url(
+pub async fn import_url(
     service: &ZapService,
     url: String,
     hostoverride: String,
@@ -49,5 +46,5 @@ pub fn import_url(
     let mut params = HashMap::new();
     params.insert("url".to_string(), url);
     params.insert("hostOverride".to_string(), hostoverride);
-    super::call(service, "openapi", "action", "importUrl", params)
+    super::call(service, "openapi", "action", "importUrl", params).await
 }

--- a/src/params.rs
+++ b/src/params.rs
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 the ZAP development team
+ * Copyright 2020 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
  * limitations under the License.
  */
 
+
 use super::ZapApiError;
 use super::ZapService;
 use serde_json::Value;
 use std::collections::HashMap;
+
 
 /**
  * This file was automatically generated.
@@ -28,8 +30,9 @@ use std::collections::HashMap;
 /**
  * Shows the parameters for the specified site, or for all sites if the site is not specified
 */
-pub fn params(service: &ZapService, site: String) -> Result<Value, ZapApiError> {
+pub async fn params(service: &ZapService, site: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("site".to_string(), site);
-    super::call(service, "params", "view", "params", params)
+    params.insert("site".to_string(), site.to_string());
+    super::call(service, "params", "view", "params", params).await
 }
+

--- a/src/pnh.rs
+++ b/src/pnh.rs
@@ -23,73 +23,74 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 /**
- * This file was automatically generated.
- */
-/**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn monitor(service: &ZapService, id: String, message: String) -> Result<Value, ZapApiError> {
+pub async fn monitor(
+    service: &ZapService,
+    id: String,
+    message: String,
+) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
     params.insert("id".to_string(), id);
     params.insert("message".to_string(), message);
-    super::call(service, "pnh", "action", "monitor", params)
+    super::call(service, "pnh", "action", "monitor", params).await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn oracle(service: &ZapService, id: String) -> Result<Value, ZapApiError> {
+pub async fn oracle(service: &ZapService, id: String) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
     params.insert("id".to_string(), id);
-    super::call(service, "pnh", "action", "oracle", params)
+    super::call(service, "pnh", "action", "oracle", params).await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn start_monitoring(service: &ZapService, url: String) -> Result<Value, ZapApiError> {
+pub async fn start_monitoring(service: &ZapService, url: String) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
     params.insert("url".to_string(), url);
-    super::call(service, "pnh", "action", "startMonitoring", params)
+    super::call(service, "pnh", "action", "startMonitoring", params).await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn stop_monitoring(service: &ZapService, id: String) -> Result<Value, ZapApiError> {
+pub async fn stop_monitoring(service: &ZapService, id: String) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
     params.insert("id".to_string(), id);
-    super::call(service, "pnh", "action", "stopMonitoring", params)
+    super::call(service, "pnh", "action", "stopMonitoring", params).await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn pnh(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn pnh(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "pnh", "other", "pnh", params)
+    super::call(service, "pnh", "other", "pnh", params).await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn manifest(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn manifest(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "pnh", "other", "manifest", params)
+    super::call(service, "pnh", "other", "manifest", params).await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn service(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn service(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "pnh", "other", "service", params)
+    super::call(service, "pnh", "other", "service", params).await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn fx_pnh_xpi(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn fx_pnh_xpi(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "pnh", "other", "fx_pnh.xpi", params)
+    super::call(service, "pnh", "other", "fx_pnh.xpi", params).await
 }

--- a/src/pscan.rs
+++ b/src/pscan.rs
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 the ZAP development team
+ * Copyright 2020 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
  * limitations under the License.
  */
 
+
 use super::ZapApiError;
 use super::ZapService;
 use serde_json::Value;
 use std::collections::HashMap;
+
 
 /**
  * This file was automatically generated.
@@ -28,126 +30,127 @@ use std::collections::HashMap;
 /**
  * Tells whether or not the passive scan should be performed only on messages that are in scope.
 */
-pub fn scan_only_in_scope(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn scan_only_in_scope(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "pscan", "view", "scanOnlyInScope", params)
+    super::call(service, "pscan", "view", "scanOnlyInScope", params).await
 }
 
 /**
  * The number of records the passive scanner still has to scan
 */
-pub fn records_to_scan(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn records_to_scan(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "pscan", "view", "recordsToScan", params)
+    super::call(service, "pscan", "view", "recordsToScan", params).await
 }
 
 /**
  * Lists all passive scanners with its ID, name, enabled state and alert threshold.
 */
-pub fn scanners(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn scanners(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "pscan", "view", "scanners", params)
+    super::call(service, "pscan", "view", "scanners", params).await
 }
 
 /**
  * Show information about the passive scan rule currently being run (if any).
 */
-pub fn current_rule(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn current_rule(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "pscan", "view", "currentRule", params)
+    super::call(service, "pscan", "view", "currentRule", params).await
 }
 
 /**
  * Gets the maximum number of alerts a passive scan rule should raise.
 */
-pub fn max_alerts_per_rule(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn max_alerts_per_rule(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "pscan", "view", "maxAlertsPerRule", params)
+    super::call(service, "pscan", "view", "maxAlertsPerRule", params).await
 }
 
 /**
  * Sets whether or not the passive scanning is enabled (Note: the enabled state is not persisted).
 */
-pub fn set_enabled(service: &ZapService, enabled: String) -> Result<Value, ZapApiError> {
+pub async fn set_enabled(service: &ZapService, enabled: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("enabled".to_string(), enabled);
-    super::call(service, "pscan", "action", "setEnabled", params)
+    params.insert("enabled".to_string(), enabled.to_string());
+    super::call(service, "pscan", "action", "setEnabled", params).await
 }
 
 /**
  * Sets whether or not the passive scan should be performed only on messages that are in scope.
 */
-pub fn set_scan_only_in_scope(
-    service: &ZapService,
-    onlyinscope: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_scan_only_in_scope(service: &ZapService, onlyinscope: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("onlyInScope".to_string(), onlyinscope);
-    super::call(service, "pscan", "action", "setScanOnlyInScope", params)
+    params.insert("onlyInScope".to_string(), onlyinscope.to_string());
+    super::call(service, "pscan", "action", "setScanOnlyInScope", params).await
 }
 
 /**
  * Enables all passive scanners
 */
-pub fn enable_all_scanners(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn enable_all_scanners(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "pscan", "action", "enableAllScanners", params)
+    super::call(service, "pscan", "action", "enableAllScanners", params).await
 }
 
 /**
  * Disables all passive scanners
 */
-pub fn disable_all_scanners(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn disable_all_scanners(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "pscan", "action", "disableAllScanners", params)
+    super::call(service, "pscan", "action", "disableAllScanners", params).await
 }
 
 /**
  * Enables all passive scanners with the given IDs (comma separated list of IDs)
 */
-pub fn enable_scanners(service: &ZapService, ids: String) -> Result<Value, ZapApiError> {
+pub async fn enable_scanners(service: &ZapService, ids: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("ids".to_string(), ids);
-    super::call(service, "pscan", "action", "enableScanners", params)
+    params.insert("ids".to_string(), ids.to_string());
+    super::call(service, "pscan", "action", "enableScanners", params).await
 }
 
 /**
  * Disables all passive scanners with the given IDs (comma separated list of IDs)
 */
-pub fn disable_scanners(service: &ZapService, ids: String) -> Result<Value, ZapApiError> {
+pub async fn disable_scanners(service: &ZapService, ids: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("ids".to_string(), ids);
-    super::call(service, "pscan", "action", "disableScanners", params)
+    params.insert("ids".to_string(), ids.to_string());
+    super::call(service, "pscan", "action", "disableScanners", params).await
 }
 
 /**
  * Sets the alert threshold of the passive scanner with the given ID, accepted values for alert threshold: OFF, DEFAULT, LOW, MEDIUM and HIGH
 */
-pub fn set_scanner_alert_threshold(
-    service: &ZapService,
-    id: String,
-    alertthreshold: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_scanner_alert_threshold(service: &ZapService, id: &str, alertthreshold: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("id".to_string(), id);
-    params.insert("alertThreshold".to_string(), alertthreshold);
-    super::call(
-        service,
-        "pscan",
-        "action",
-        "setScannerAlertThreshold",
-        params,
-    )
+    params.insert("id".to_string(), id.to_string());
+    params.insert("alertThreshold".to_string(), alertthreshold.to_string());
+    super::call(service, "pscan", "action", "setScannerAlertThreshold", params).await
 }
 
 /**
  * Sets the maximum number of alerts a passive scan rule should raise.
 */
-pub fn set_max_alerts_per_rule(
-    service: &ZapService,
-    maxalerts: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_max_alerts_per_rule(service: &ZapService, maxalerts: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("maxAlerts".to_string(), maxalerts);
-    super::call(service, "pscan", "action", "setMaxAlertsPerRule", params)
+    params.insert("maxAlerts".to_string(), maxalerts.to_string());
+    super::call(service, "pscan", "action", "setMaxAlertsPerRule", params).await
 }
+
+/**
+ * Disables all passive scan tags.
+*/
+pub async fn disable_all_tags(service: &ZapService) -> Result<Value, ZapApiError> {
+    let params = HashMap::new();
+    super::call(service, "pscan", "action", "disableAllTags", params).await
+}
+
+/**
+ * Enables all passive scan tags.
+*/
+pub async fn enable_all_tags(service: &ZapService) -> Result<Value, ZapApiError> {
+    let params = HashMap::new();
+    super::call(service, "pscan", "action", "enableAllTags", params).await
+}
+

--- a/src/replacer.rs
+++ b/src/replacer.rs
@@ -23,16 +23,13 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 /**
- * This file was automatically generated.
- */
-/**
  * Returns full details of all of the rules
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn rules(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn rules(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "replacer", "view", "rules", params)
+    super::call(service, "replacer", "view", "rules", params).await
 }
 
 /**
@@ -41,7 +38,7 @@ pub fn rules(service: &ZapService) -> Result<Value, ZapApiError> {
  * This component is optional and therefore the API will only work if it is installed
 */
 #[allow(clippy::too_many_arguments)]
-pub fn add_rule(
+pub async fn add_rule(
     service: &ZapService,
     description: String,
     enabled: String,
@@ -59,7 +56,7 @@ pub fn add_rule(
     params.insert("matchString".to_string(), matchstring);
     params.insert("replacement".to_string(), replacement);
     params.insert("initiators".to_string(), initiators);
-    super::call(service, "replacer", "action", "addRule", params)
+    super::call(service, "replacer", "action", "addRule", params).await
 }
 
 /**
@@ -67,10 +64,10 @@ pub fn add_rule(
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn remove_rule(service: &ZapService, description: String) -> Result<Value, ZapApiError> {
+pub async fn remove_rule(service: &ZapService, description: String) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
     params.insert("description".to_string(), description);
-    super::call(service, "replacer", "action", "removeRule", params)
+    super::call(service, "replacer", "action", "removeRule", params).await
 }
 
 /**
@@ -78,7 +75,7 @@ pub fn remove_rule(service: &ZapService, description: String) -> Result<Value, Z
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn set_enabled(
+pub async fn set_enabled(
     service: &ZapService,
     description: String,
     bool: String,
@@ -86,5 +83,5 @@ pub fn set_enabled(
     let mut params = HashMap::new();
     params.insert("description".to_string(), description);
     params.insert("bool".to_string(), bool);
-    super::call(service, "replacer", "action", "setEnabled", params)
+    super::call(service, "replacer", "action", "setEnabled", params).await
 }

--- a/src/reveal.rs
+++ b/src/reveal.rs
@@ -23,16 +23,13 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 /**
- * This file was automatically generated.
- */
-/**
  * Tells if shows hidden fields and enables disabled fields
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn reveal(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn reveal(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "reveal", "view", "reveal", params)
+    super::call(service, "reveal", "view", "reveal", params).await
 }
 
 /**
@@ -40,8 +37,8 @@ pub fn reveal(service: &ZapService) -> Result<Value, ZapApiError> {
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn set_reveal(service: &ZapService, reveal: String) -> Result<Value, ZapApiError> {
+pub async fn set_reveal(service: &ZapService, reveal: String) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
     params.insert("reveal".to_string(), reveal);
-    super::call(service, "reveal", "action", "setReveal", params)
+    super::call(service, "reveal", "action", "setReveal", params).await
 }

--- a/src/rule_config.rs
+++ b/src/rule_config.rs
@@ -1,0 +1,73 @@
+/* Zed Attack Proxy (ZAP) and its related class files.
+ *
+ * ZAP is an HTTP/HTTPS proxy for assessing web application security.
+ *
+ * Copyright 2020 the ZAP development team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+use super::ZapApiError;
+use super::ZapService;
+use serde_json::Value;
+use std::collections::HashMap;
+
+
+/**
+ * This file was automatically generated.
+ */
+/**
+ * Show the specified rule configuration
+*/
+pub async fn rule_config_value(service: &ZapService, key: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("key".to_string(), key.to_string());
+    super::call(service, "ruleConfig", "view", "ruleConfigValue", params).await
+}
+
+/**
+ * Show all of the rule configurations
+*/
+pub async fn all_rule_configs(service: &ZapService) -> Result<Value, ZapApiError> {
+    let params = HashMap::new();
+    super::call(service, "ruleConfig", "view", "allRuleConfigs", params).await
+}
+
+/**
+ * Reset the specified rule configuration, which must already exist
+*/
+pub async fn reset_rule_config_value(service: &ZapService, key: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("key".to_string(), key.to_string());
+    super::call(service, "ruleConfig", "action", "resetRuleConfigValue", params).await
+}
+
+/**
+ * Reset all of the rule configurations
+*/
+pub async fn reset_all_rule_config_values(service: &ZapService) -> Result<Value, ZapApiError> {
+    let params = HashMap::new();
+    super::call(service, "ruleConfig", "action", "resetAllRuleConfigValues", params).await
+}
+
+/**
+ * Set the specified rule configuration, which must already exist
+*/
+pub async fn set_rule_config_value(service: &ZapService, key: &str, value: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("key".to_string(), key.to_string());
+    params.insert("value".to_string(), value.to_string());
+    super::call(service, "ruleConfig", "action", "setRuleConfigValue", params).await
+}
+

--- a/src/script.rs
+++ b/src/script.rs
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 the ZAP development team
+ * Copyright 2020 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
  * limitations under the License.
  */
 
+
 use super::ZapApiError;
 use super::ZapService;
 use serde_json::Value;
 use std::collections::HashMap;
+
 
 /**
  * This file was automatically generated.
@@ -28,194 +30,222 @@ use std::collections::HashMap;
 /**
  * Lists the script engines available
 */
-pub fn list_engines(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn list_engines(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "script", "view", "listEngines", params)
+    super::call(service, "script", "view", "listEngines", params).await
 }
 
 /**
  * Lists the script types available.
 */
-pub fn list_types(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn list_types(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "script", "view", "listTypes", params)
+    super::call(service, "script", "view", "listTypes", params).await
 }
 
 /**
  * Lists the scripts available, with its engine, name, description, type and error state.
 */
-pub fn list_scripts(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn list_scripts(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "script", "view", "listScripts", params)
+    super::call(service, "script", "view", "listScripts", params).await
 }
 
 /**
  * Gets the value of the global variable with the given key. Returns an API error (DOES_NOT_EXIST) if no value was previously set.
 */
-pub fn global_var(service: &ZapService, varkey: String) -> Result<Value, ZapApiError> {
+pub async fn global_var(service: &ZapService, varkey: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("varKey".to_string(), varkey);
-    super::call(service, "script", "view", "globalVar", params)
+    params.insert("varKey".to_string(), varkey.to_string());
+    super::call(service, "script", "view", "globalVar", params).await
+}
+
+/**
+ * Gets the value (string representation) of a global custom variable. Returns an API error (DOES_NOT_EXIST) if no value was previously set.
+*/
+pub async fn global_custom_var(service: &ZapService, varkey: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("varKey".to_string(), varkey.to_string());
+    super::call(service, "script", "view", "globalCustomVar", params).await
 }
 
 /**
  * Gets all the global variables (key/value pairs).
 */
-pub fn global_vars(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn global_vars(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "script", "view", "globalVars", params)
+    super::call(service, "script", "view", "globalVars", params).await
+}
+
+/**
+ * Gets all the global custom variables (key/value pairs, the value is the string representation).
+*/
+pub async fn global_custom_vars(service: &ZapService) -> Result<Value, ZapApiError> {
+    let params = HashMap::new();
+    super::call(service, "script", "view", "globalCustomVars", params).await
 }
 
 /**
  * Gets the value of the variable with the given key for the given script. Returns an API error (DOES_NOT_EXIST) if no script with the given name exists or if no value was previously set.
 */
-pub fn script_var(
-    service: &ZapService,
-    scriptname: String,
-    varkey: String,
-) -> Result<Value, ZapApiError> {
+pub async fn script_var(service: &ZapService, scriptname: &str, varkey: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scriptName".to_string(), scriptname);
-    params.insert("varKey".to_string(), varkey);
-    super::call(service, "script", "view", "scriptVar", params)
+    params.insert("scriptName".to_string(), scriptname.to_string());
+    params.insert("varKey".to_string(), varkey.to_string());
+    super::call(service, "script", "view", "scriptVar", params).await
+}
+
+/**
+ * Gets the value (string representation) of a custom variable. Returns an API error (DOES_NOT_EXIST) if no script with the given name exists or if no value was previously set.
+*/
+pub async fn script_custom_var(service: &ZapService, scriptname: &str, varkey: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("scriptName".to_string(), scriptname.to_string());
+    params.insert("varKey".to_string(), varkey.to_string());
+    super::call(service, "script", "view", "scriptCustomVar", params).await
 }
 
 /**
  * Gets all the variables (key/value pairs) of the given script. Returns an API error (DOES_NOT_EXIST) if no script with the given name exists.
 */
-pub fn script_vars(service: &ZapService, scriptname: String) -> Result<Value, ZapApiError> {
+pub async fn script_vars(service: &ZapService, scriptname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scriptName".to_string(), scriptname);
-    super::call(service, "script", "view", "scriptVars", params)
+    params.insert("scriptName".to_string(), scriptname.to_string());
+    super::call(service, "script", "view", "scriptVars", params).await
+}
+
+/**
+ * Gets all the custom variables (key/value pairs, the value is the string representation) of a script. Returns an API error (DOES_NOT_EXIST) if no script with the given name exists.
+*/
+pub async fn script_custom_vars(service: &ZapService, scriptname: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("scriptName".to_string(), scriptname.to_string());
+    super::call(service, "script", "view", "scriptCustomVars", params).await
 }
 
 /**
  * Enables the script with the given name
 */
-pub fn enable(service: &ZapService, scriptname: String) -> Result<Value, ZapApiError> {
+pub async fn enable(service: &ZapService, scriptname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scriptName".to_string(), scriptname);
-    super::call(service, "script", "action", "enable", params)
+    params.insert("scriptName".to_string(), scriptname.to_string());
+    super::call(service, "script", "action", "enable", params).await
 }
 
 /**
  * Disables the script with the given name
 */
-pub fn disable(service: &ZapService, scriptname: String) -> Result<Value, ZapApiError> {
+pub async fn disable(service: &ZapService, scriptname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scriptName".to_string(), scriptname);
-    super::call(service, "script", "action", "disable", params)
+    params.insert("scriptName".to_string(), scriptname.to_string());
+    super::call(service, "script", "action", "disable", params).await
 }
 
 /**
  * Loads a script into ZAP from the given local file, with the given name, type and engine, optionally with a description, and a charset name to read the script (the charset name is required if the script is not in UTF-8, for example, in ISO-8859-1).
 */
-pub fn load(
-    service: &ZapService,
-    scriptname: String,
-    scripttype: String,
-    scriptengine: String,
-    filename: String,
-    scriptdescription: String,
-    charset: String,
-) -> Result<Value, ZapApiError> {
+pub async fn load(service: &ZapService, scriptname: &str, scripttype: &str, scriptengine: &str, filename: &str, scriptdescription: &str, charset: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scriptName".to_string(), scriptname);
-    params.insert("scriptType".to_string(), scripttype);
-    params.insert("scriptEngine".to_string(), scriptengine);
-    params.insert("fileName".to_string(), filename);
-    params.insert("scriptDescription".to_string(), scriptdescription);
-    params.insert("charset".to_string(), charset);
-    super::call(service, "script", "action", "load", params)
+    params.insert("scriptName".to_string(), scriptname.to_string());
+    params.insert("scriptType".to_string(), scripttype.to_string());
+    params.insert("scriptEngine".to_string(), scriptengine.to_string());
+    params.insert("fileName".to_string(), filename.to_string());
+    params.insert("scriptDescription".to_string(), scriptdescription.to_string());
+    params.insert("charset".to_string(), charset.to_string());
+    super::call(service, "script", "action", "load", params).await
 }
 
 /**
  * Removes the script with the given name
 */
-pub fn remove(service: &ZapService, scriptname: String) -> Result<Value, ZapApiError> {
+pub async fn remove(service: &ZapService, scriptname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scriptName".to_string(), scriptname);
-    super::call(service, "script", "action", "remove", params)
+    params.insert("scriptName".to_string(), scriptname.to_string());
+    super::call(service, "script", "action", "remove", params).await
 }
 
 /**
  * Runs the stand alone script with the given name
 */
-pub fn run_stand_alone_script(
-    service: &ZapService,
-    scriptname: String,
-) -> Result<Value, ZapApiError> {
+pub async fn run_stand_alone_script(service: &ZapService, scriptname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scriptName".to_string(), scriptname);
-    super::call(service, "script", "action", "runStandAloneScript", params)
+    params.insert("scriptName".to_string(), scriptname.to_string());
+    super::call(service, "script", "action", "runStandAloneScript", params).await
 }
 
 /**
  * Clears the global variable with the given key.
 */
-pub fn clear_global_var(service: &ZapService, varkey: String) -> Result<Value, ZapApiError> {
+pub async fn clear_global_var(service: &ZapService, varkey: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("varKey".to_string(), varkey);
-    super::call(service, "script", "action", "clearGlobalVar", params)
+    params.insert("varKey".to_string(), varkey.to_string());
+    super::call(service, "script", "action", "clearGlobalVar", params).await
+}
+
+/**
+ * Clears a global custom variable.
+*/
+pub async fn clear_global_custom_var(service: &ZapService, varkey: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("varKey".to_string(), varkey.to_string());
+    super::call(service, "script", "action", "clearGlobalCustomVar", params).await
 }
 
 /**
  * Clears the global variables.
 */
-pub fn clear_global_vars(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn clear_global_vars(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "script", "action", "clearGlobalVars", params)
+    super::call(service, "script", "action", "clearGlobalVars", params).await
 }
 
 /**
  * Clears the variable with the given key of the given script. Returns an API error (DOES_NOT_EXIST) if no script with the given name exists.
 */
-pub fn clear_script_var(
-    service: &ZapService,
-    scriptname: String,
-    varkey: String,
-) -> Result<Value, ZapApiError> {
+pub async fn clear_script_var(service: &ZapService, scriptname: &str, varkey: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scriptName".to_string(), scriptname);
-    params.insert("varKey".to_string(), varkey);
-    super::call(service, "script", "action", "clearScriptVar", params)
+    params.insert("scriptName".to_string(), scriptname.to_string());
+    params.insert("varKey".to_string(), varkey.to_string());
+    super::call(service, "script", "action", "clearScriptVar", params).await
+}
+
+/**
+ * Clears a script custom variable.
+*/
+pub async fn clear_script_custom_var(service: &ZapService, scriptname: &str, varkey: &str) -> Result<Value, ZapApiError> {
+    let mut params = HashMap::new();
+    params.insert("scriptName".to_string(), scriptname.to_string());
+    params.insert("varKey".to_string(), varkey.to_string());
+    super::call(service, "script", "action", "clearScriptCustomVar", params).await
 }
 
 /**
  * Clears the variables of the given script. Returns an API error (DOES_NOT_EXIST) if no script with the given name exists.
 */
-pub fn clear_script_vars(service: &ZapService, scriptname: String) -> Result<Value, ZapApiError> {
+pub async fn clear_script_vars(service: &ZapService, scriptname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scriptName".to_string(), scriptname);
-    super::call(service, "script", "action", "clearScriptVars", params)
+    params.insert("scriptName".to_string(), scriptname.to_string());
+    super::call(service, "script", "action", "clearScriptVars", params).await
 }
 
 /**
  * Sets the value of the variable with the given key of the given script. Returns an API error (DOES_NOT_EXIST) if no script with the given name exists.
 */
-pub fn set_script_var(
-    service: &ZapService,
-    scriptname: String,
-    varkey: String,
-    varvalue: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_script_var(service: &ZapService, scriptname: &str, varkey: &str, varvalue: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scriptName".to_string(), scriptname);
-    params.insert("varKey".to_string(), varkey);
-    params.insert("varValue".to_string(), varvalue);
-    super::call(service, "script", "action", "setScriptVar", params)
+    params.insert("scriptName".to_string(), scriptname.to_string());
+    params.insert("varKey".to_string(), varkey.to_string());
+    params.insert("varValue".to_string(), varvalue.to_string());
+    super::call(service, "script", "action", "setScriptVar", params).await
 }
 
 /**
  * Sets the value of the global variable with the given key.
 */
-pub fn set_global_var(
-    service: &ZapService,
-    varkey: String,
-    varvalue: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_global_var(service: &ZapService, varkey: &str, varvalue: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("varKey".to_string(), varkey);
-    params.insert("varValue".to_string(), varvalue);
-    super::call(service, "script", "action", "setGlobalVar", params)
+    params.insert("varKey".to_string(), varkey.to_string());
+    params.insert("varValue".to_string(), varvalue.to_string());
+    super::call(service, "script", "action", "setGlobalVar", params).await
 }
+

--- a/src/search.rs
+++ b/src/search.rs
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 the ZAP development team
+ * Copyright 2020 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
  * limitations under the License.
  */
 
+
 use super::ZapApiError;
 use super::ZapService;
 use serde_json::Value;
 use std::collections::HashMap;
+
 
 /**
  * This file was automatically generated.
@@ -28,215 +30,144 @@ use std::collections::HashMap;
 /**
  * Returns the URLs of the HTTP messages that match the given regular expression in the URL optionally filtered by URL and paginated with 'start' position and 'count' of messages.
 */
-pub fn urls_by_url_regex(
-    service: &ZapService,
-    regex: String,
-    baseurl: String,
-    start: String,
-    count: String,
-) -> Result<Value, ZapApiError> {
+pub async fn urls_by_url_regex(service: &ZapService, regex: &str, baseurl: &str, start: &str, count: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("regex".to_string(), regex);
-    params.insert("baseurl".to_string(), baseurl);
-    params.insert("start".to_string(), start);
-    params.insert("count".to_string(), count);
-    super::call(service, "search", "view", "urlsByUrlRegex", params)
+    params.insert("regex".to_string(), regex.to_string());
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    params.insert("start".to_string(), start.to_string());
+    params.insert("count".to_string(), count.to_string());
+    super::call(service, "search", "view", "urlsByUrlRegex", params).await
 }
 
 /**
  * Returns the URLs of the HTTP messages that match the given regular expression in the request optionally filtered by URL and paginated with 'start' position and 'count' of messages.
 */
-pub fn urls_by_request_regex(
-    service: &ZapService,
-    regex: String,
-    baseurl: String,
-    start: String,
-    count: String,
-) -> Result<Value, ZapApiError> {
+pub async fn urls_by_request_regex(service: &ZapService, regex: &str, baseurl: &str, start: &str, count: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("regex".to_string(), regex);
-    params.insert("baseurl".to_string(), baseurl);
-    params.insert("start".to_string(), start);
-    params.insert("count".to_string(), count);
-    super::call(service, "search", "view", "urlsByRequestRegex", params)
+    params.insert("regex".to_string(), regex.to_string());
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    params.insert("start".to_string(), start.to_string());
+    params.insert("count".to_string(), count.to_string());
+    super::call(service, "search", "view", "urlsByRequestRegex", params).await
 }
 
 /**
  * Returns the URLs of the HTTP messages that match the given regular expression in the response optionally filtered by URL and paginated with 'start' position and 'count' of messages.
 */
-pub fn urls_by_response_regex(
-    service: &ZapService,
-    regex: String,
-    baseurl: String,
-    start: String,
-    count: String,
-) -> Result<Value, ZapApiError> {
+pub async fn urls_by_response_regex(service: &ZapService, regex: &str, baseurl: &str, start: &str, count: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("regex".to_string(), regex);
-    params.insert("baseurl".to_string(), baseurl);
-    params.insert("start".to_string(), start);
-    params.insert("count".to_string(), count);
-    super::call(service, "search", "view", "urlsByResponseRegex", params)
+    params.insert("regex".to_string(), regex.to_string());
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    params.insert("start".to_string(), start.to_string());
+    params.insert("count".to_string(), count.to_string());
+    super::call(service, "search", "view", "urlsByResponseRegex", params).await
 }
 
 /**
  * Returns the URLs of the HTTP messages that match the given regular expression in the header(s) optionally filtered by URL and paginated with 'start' position and 'count' of messages.
 */
-pub fn urls_by_header_regex(
-    service: &ZapService,
-    regex: String,
-    baseurl: String,
-    start: String,
-    count: String,
-) -> Result<Value, ZapApiError> {
+pub async fn urls_by_header_regex(service: &ZapService, regex: &str, baseurl: &str, start: &str, count: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("regex".to_string(), regex);
-    params.insert("baseurl".to_string(), baseurl);
-    params.insert("start".to_string(), start);
-    params.insert("count".to_string(), count);
-    super::call(service, "search", "view", "urlsByHeaderRegex", params)
+    params.insert("regex".to_string(), regex.to_string());
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    params.insert("start".to_string(), start.to_string());
+    params.insert("count".to_string(), count.to_string());
+    super::call(service, "search", "view", "urlsByHeaderRegex", params).await
 }
 
 /**
  * Returns the HTTP messages that match the given regular expression in the URL optionally filtered by URL and paginated with 'start' position and 'count' of messages.
 */
-pub fn messages_by_url_regex(
-    service: &ZapService,
-    regex: String,
-    baseurl: String,
-    start: String,
-    count: String,
-) -> Result<Value, ZapApiError> {
+pub async fn messages_by_url_regex(service: &ZapService, regex: &str, baseurl: &str, start: &str, count: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("regex".to_string(), regex);
-    params.insert("baseurl".to_string(), baseurl);
-    params.insert("start".to_string(), start);
-    params.insert("count".to_string(), count);
-    super::call(service, "search", "view", "messagesByUrlRegex", params)
+    params.insert("regex".to_string(), regex.to_string());
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    params.insert("start".to_string(), start.to_string());
+    params.insert("count".to_string(), count.to_string());
+    super::call(service, "search", "view", "messagesByUrlRegex", params).await
 }
 
 /**
  * Returns the HTTP messages that match the given regular expression in the request optionally filtered by URL and paginated with 'start' position and 'count' of messages.
 */
-pub fn messages_by_request_regex(
-    service: &ZapService,
-    regex: String,
-    baseurl: String,
-    start: String,
-    count: String,
-) -> Result<Value, ZapApiError> {
+pub async fn messages_by_request_regex(service: &ZapService, regex: &str, baseurl: &str, start: &str, count: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("regex".to_string(), regex);
-    params.insert("baseurl".to_string(), baseurl);
-    params.insert("start".to_string(), start);
-    params.insert("count".to_string(), count);
-    super::call(service, "search", "view", "messagesByRequestRegex", params)
+    params.insert("regex".to_string(), regex.to_string());
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    params.insert("start".to_string(), start.to_string());
+    params.insert("count".to_string(), count.to_string());
+    super::call(service, "search", "view", "messagesByRequestRegex", params).await
 }
 
 /**
  * Returns the HTTP messages that match the given regular expression in the response optionally filtered by URL and paginated with 'start' position and 'count' of messages.
 */
-pub fn messages_by_response_regex(
-    service: &ZapService,
-    regex: String,
-    baseurl: String,
-    start: String,
-    count: String,
-) -> Result<Value, ZapApiError> {
+pub async fn messages_by_response_regex(service: &ZapService, regex: &str, baseurl: &str, start: &str, count: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("regex".to_string(), regex);
-    params.insert("baseurl".to_string(), baseurl);
-    params.insert("start".to_string(), start);
-    params.insert("count".to_string(), count);
-    super::call(service, "search", "view", "messagesByResponseRegex", params)
+    params.insert("regex".to_string(), regex.to_string());
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    params.insert("start".to_string(), start.to_string());
+    params.insert("count".to_string(), count.to_string());
+    super::call(service, "search", "view", "messagesByResponseRegex", params).await
 }
 
 /**
  * Returns the HTTP messages that match the given regular expression in the header(s) optionally filtered by URL and paginated with 'start' position and 'count' of messages.
 */
-pub fn messages_by_header_regex(
-    service: &ZapService,
-    regex: String,
-    baseurl: String,
-    start: String,
-    count: String,
-) -> Result<Value, ZapApiError> {
+pub async fn messages_by_header_regex(service: &ZapService, regex: &str, baseurl: &str, start: &str, count: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("regex".to_string(), regex);
-    params.insert("baseurl".to_string(), baseurl);
-    params.insert("start".to_string(), start);
-    params.insert("count".to_string(), count);
-    super::call(service, "search", "view", "messagesByHeaderRegex", params)
+    params.insert("regex".to_string(), regex.to_string());
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    params.insert("start".to_string(), start.to_string());
+    params.insert("count".to_string(), count.to_string());
+    super::call(service, "search", "view", "messagesByHeaderRegex", params).await
 }
 
 /**
  * Returns the HTTP messages, in HAR format, that match the given regular expression in the URL optionally filtered by URL and paginated with 'start' position and 'count' of messages.
 */
-pub fn har_by_url_regex(
-    service: &ZapService,
-    regex: String,
-    baseurl: String,
-    start: String,
-    count: String,
-) -> Result<Value, ZapApiError> {
+pub async fn har_by_url_regex(service: &ZapService, regex: &str, baseurl: &str, start: &str, count: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("regex".to_string(), regex);
-    params.insert("baseurl".to_string(), baseurl);
-    params.insert("start".to_string(), start);
-    params.insert("count".to_string(), count);
-    super::call(service, "search", "other", "harByUrlRegex", params)
+    params.insert("regex".to_string(), regex.to_string());
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    params.insert("start".to_string(), start.to_string());
+    params.insert("count".to_string(), count.to_string());
+    super::call(service, "search", "other", "harByUrlRegex", params).await
 }
 
 /**
  * Returns the HTTP messages, in HAR format, that match the given regular expression in the request optionally filtered by URL and paginated with 'start' position and 'count' of messages.
 */
-pub fn har_by_request_regex(
-    service: &ZapService,
-    regex: String,
-    baseurl: String,
-    start: String,
-    count: String,
-) -> Result<Value, ZapApiError> {
+pub async fn har_by_request_regex(service: &ZapService, regex: &str, baseurl: &str, start: &str, count: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("regex".to_string(), regex);
-    params.insert("baseurl".to_string(), baseurl);
-    params.insert("start".to_string(), start);
-    params.insert("count".to_string(), count);
-    super::call(service, "search", "other", "harByRequestRegex", params)
+    params.insert("regex".to_string(), regex.to_string());
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    params.insert("start".to_string(), start.to_string());
+    params.insert("count".to_string(), count.to_string());
+    super::call(service, "search", "other", "harByRequestRegex", params).await
 }
 
 /**
  * Returns the HTTP messages, in HAR format, that match the given regular expression in the response optionally filtered by URL and paginated with 'start' position and 'count' of messages.
 */
-pub fn har_by_response_regex(
-    service: &ZapService,
-    regex: String,
-    baseurl: String,
-    start: String,
-    count: String,
-) -> Result<Value, ZapApiError> {
+pub async fn har_by_response_regex(service: &ZapService, regex: &str, baseurl: &str, start: &str, count: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("regex".to_string(), regex);
-    params.insert("baseurl".to_string(), baseurl);
-    params.insert("start".to_string(), start);
-    params.insert("count".to_string(), count);
-    super::call(service, "search", "other", "harByResponseRegex", params)
+    params.insert("regex".to_string(), regex.to_string());
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    params.insert("start".to_string(), start.to_string());
+    params.insert("count".to_string(), count.to_string());
+    super::call(service, "search", "other", "harByResponseRegex", params).await
 }
 
 /**
  * Returns the HTTP messages, in HAR format, that match the given regular expression in the header(s) optionally filtered by URL and paginated with 'start' position and 'count' of messages.
 */
-pub fn har_by_header_regex(
-    service: &ZapService,
-    regex: String,
-    baseurl: String,
-    start: String,
-    count: String,
-) -> Result<Value, ZapApiError> {
+pub async fn har_by_header_regex(service: &ZapService, regex: &str, baseurl: &str, start: &str, count: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("regex".to_string(), regex);
-    params.insert("baseurl".to_string(), baseurl);
-    params.insert("start".to_string(), start);
-    params.insert("count".to_string(), count);
-    super::call(service, "search", "other", "harByHeaderRegex", params)
+    params.insert("regex".to_string(), regex.to_string());
+    params.insert("baseurl".to_string(), baseurl.to_string());
+    params.insert("start".to_string(), start.to_string());
+    params.insert("count".to_string(), count.to_string());
+    super::call(service, "search", "other", "harByHeaderRegex", params).await
 }
+

--- a/src/selenium.rs
+++ b/src/selenium.rs
@@ -23,14 +23,11 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 /**
- * This file was automatically generated.
- */
-/**
  * Returns the current path to ChromeDriver
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn option_chrome_driver_path(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_chrome_driver_path(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
     super::call(
         service,
@@ -39,6 +36,7 @@ pub fn option_chrome_driver_path(service: &ZapService) -> Result<Value, ZapApiEr
         "optionChromeDriverPath",
         params,
     )
+    .await
 }
 
 /**
@@ -46,7 +44,7 @@ pub fn option_chrome_driver_path(service: &ZapService) -> Result<Value, ZapApiEr
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn option_firefox_binary_path(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_firefox_binary_path(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
     super::call(
         service,
@@ -55,6 +53,7 @@ pub fn option_firefox_binary_path(service: &ZapService) -> Result<Value, ZapApiE
         "optionFirefoxBinaryPath",
         params,
     )
+    .await
 }
 
 /**
@@ -62,7 +61,7 @@ pub fn option_firefox_binary_path(service: &ZapService) -> Result<Value, ZapApiE
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn option_firefox_driver_path(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_firefox_driver_path(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
     super::call(
         service,
@@ -71,14 +70,15 @@ pub fn option_firefox_driver_path(service: &ZapService) -> Result<Value, ZapApiE
         "optionFirefoxDriverPath",
         params,
     )
+    .await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn option_ie_driver_path(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_ie_driver_path(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "selenium", "view", "optionIeDriverPath", params)
+    super::call(service, "selenium", "view", "optionIeDriverPath", params).await
 }
 
 /**
@@ -86,7 +86,7 @@ pub fn option_ie_driver_path(service: &ZapService) -> Result<Value, ZapApiError>
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn option_phantom_js_binary_path(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_phantom_js_binary_path(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
     super::call(
         service,
@@ -95,6 +95,7 @@ pub fn option_phantom_js_binary_path(service: &ZapService) -> Result<Value, ZapA
         "optionPhantomJsBinaryPath",
         params,
     )
+    .await
 }
 
 /**
@@ -102,7 +103,7 @@ pub fn option_phantom_js_binary_path(service: &ZapService) -> Result<Value, ZapA
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn set_option_chrome_driver_path(
+pub async fn set_option_chrome_driver_path(
     service: &ZapService,
     string: String,
 ) -> Result<Value, ZapApiError> {
@@ -115,6 +116,7 @@ pub fn set_option_chrome_driver_path(
         "setOptionChromeDriverPath",
         params,
     )
+    .await
 }
 
 /**
@@ -122,7 +124,7 @@ pub fn set_option_chrome_driver_path(
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn set_option_firefox_binary_path(
+pub async fn set_option_firefox_binary_path(
     service: &ZapService,
     string: String,
 ) -> Result<Value, ZapApiError> {
@@ -135,6 +137,7 @@ pub fn set_option_firefox_binary_path(
         "setOptionFirefoxBinaryPath",
         params,
     )
+    .await
 }
 
 /**
@@ -142,7 +145,7 @@ pub fn set_option_firefox_binary_path(
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn set_option_firefox_driver_path(
+pub async fn set_option_firefox_driver_path(
     service: &ZapService,
     string: String,
 ) -> Result<Value, ZapApiError> {
@@ -155,12 +158,13 @@ pub fn set_option_firefox_driver_path(
         "setOptionFirefoxDriverPath",
         params,
     )
+    .await
 }
 
 /**
  * This component is optional and therefore the API will only work if it is installed
  */
-pub fn set_option_ie_driver_path(
+pub async fn set_option_ie_driver_path(
     service: &ZapService,
     string: String,
 ) -> Result<Value, ZapApiError> {
@@ -173,6 +177,7 @@ pub fn set_option_ie_driver_path(
         "setOptionIeDriverPath",
         params,
     )
+    .await
 }
 
 /**
@@ -180,7 +185,7 @@ pub fn set_option_ie_driver_path(
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn set_option_phantom_js_binary_path(
+pub async fn set_option_phantom_js_binary_path(
     service: &ZapService,
     string: String,
 ) -> Result<Value, ZapApiError> {
@@ -193,4 +198,5 @@ pub fn set_option_phantom_js_binary_path(
         "setOptionPhantomJsBinaryPath",
         params,
     )
+    .await
 }

--- a/src/session_management.rs
+++ b/src/session_management.rs
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 the ZAP development team
+ * Copyright 2020 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
  * limitations under the License.
  */
 
+
 use super::ZapApiError;
 use super::ZapService;
 use serde_json::Value;
 use std::collections::HashMap;
+
 
 /**
  * This file was automatically generated.
@@ -28,73 +30,37 @@ use std::collections::HashMap;
 /**
  * Gets the name of the session management methods.
 */
-pub fn get_supported_session_management_methods(
-    service: &ZapService,
-) -> Result<Value, ZapApiError> {
+pub async fn get_supported_session_management_methods(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "sessionManagement",
-        "view",
-        "getSupportedSessionManagementMethods",
-        params,
-    )
+    super::call(service, "sessionManagement", "view", "getSupportedSessionManagementMethods", params).await
 }
 
 /**
  * Gets the configuration parameters for the session management method with the given name.
 */
-pub fn get_session_management_method_config_params(
-    service: &ZapService,
-    methodname: String,
-) -> Result<Value, ZapApiError> {
+pub async fn get_session_management_method_config_params(service: &ZapService, methodname: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("methodName".to_string(), methodname);
-    super::call(
-        service,
-        "sessionManagement",
-        "view",
-        "getSessionManagementMethodConfigParams",
-        params,
-    )
+    params.insert("methodName".to_string(), methodname.to_string());
+    super::call(service, "sessionManagement", "view", "getSessionManagementMethodConfigParams", params).await
 }
 
 /**
  * Gets the name of the session management method for the context with the given ID.
 */
-pub fn get_session_management_method(
-    service: &ZapService,
-    contextid: String,
-) -> Result<Value, ZapApiError> {
+pub async fn get_session_management_method(service: &ZapService, contextid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    super::call(
-        service,
-        "sessionManagement",
-        "view",
-        "getSessionManagementMethod",
-        params,
-    )
+    params.insert("contextId".to_string(), contextid.to_string());
+    super::call(service, "sessionManagement", "view", "getSessionManagementMethod", params).await
 }
 
 /**
  * Sets the session management method for the context with the given ID.
 */
-pub fn set_session_management_method(
-    service: &ZapService,
-    contextid: String,
-    methodname: String,
-    methodconfigparams: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_session_management_method(service: &ZapService, contextid: &str, methodname: &str, methodconfigparams: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    params.insert("methodName".to_string(), methodname);
-    params.insert("methodConfigParams".to_string(), methodconfigparams);
-    super::call(
-        service,
-        "sessionManagement",
-        "action",
-        "setSessionManagementMethod",
-        params,
-    )
+    params.insert("contextId".to_string(), contextid.to_string());
+    params.insert("methodName".to_string(), methodname.to_string());
+    params.insert("methodConfigParams".to_string(), methodconfigparams.to_string());
+    super::call(service, "sessionManagement", "action", "setSessionManagementMethod", params).await
 }
+

--- a/src/soap.rs
+++ b/src/soap.rs
@@ -23,17 +23,14 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 /**
- * This file was automatically generated.
- */
-/**
  * Import a WSDL definition from local file.
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn import_file(service: &ZapService, file: String) -> Result<Value, ZapApiError> {
+pub async fn import_file(service: &ZapService, file: String) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
     params.insert("file".to_string(), file);
-    super::call(service, "soap", "action", "importFile", params)
+    super::call(service, "soap", "action", "importFile", params).await
 }
 
 /**
@@ -41,8 +38,8 @@ pub fn import_file(service: &ZapService, file: String) -> Result<Value, ZapApiEr
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn import_url(service: &ZapService, url: String) -> Result<Value, ZapApiError> {
+pub async fn import_url(service: &ZapService, url: String) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
     params.insert("url".to_string(), url);
-    super::call(service, "soap", "action", "importUrl", params)
+    super::call(service, "soap", "action", "importUrl", params).await
 }

--- a/src/spider.rs
+++ b/src/spider.rs
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 the ZAP development team
+ * Copyright 2020 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,707 +17,644 @@
  * limitations under the License.
  */
 
+
 use super::ZapApiError;
 use super::ZapService;
 use serde_json::Value;
 use std::collections::HashMap;
 
+
 /**
  * This file was automatically generated.
  */
-pub fn status(service: &ZapService, scanid: String) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn status(service: &ZapService, scanid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanId".to_string(), scanid);
-    super::call(service, "spider", "view", "status", params)
+    params.insert("scanId".to_string(), scanid.to_string());
+    super::call(service, "spider", "view", "status", params).await
 }
 
-pub fn results(service: &ZapService, scanid: String) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn results(service: &ZapService, scanid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanId".to_string(), scanid);
-    super::call(service, "spider", "view", "results", params)
+    params.insert("scanId".to_string(), scanid.to_string());
+    super::call(service, "spider", "view", "results", params).await
 }
 
-pub fn full_results(service: &ZapService, scanid: String) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn full_results(service: &ZapService, scanid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanId".to_string(), scanid);
-    super::call(service, "spider", "view", "fullResults", params)
+    params.insert("scanId".to_string(), scanid.to_string());
+    super::call(service, "spider", "view", "fullResults", params).await
 }
 
-pub fn scans(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn scans(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "scans", params)
+    super::call(service, "spider", "view", "scans", params).await
 }
 
 /**
  * Gets the regexes of URLs excluded from the spider scans.
 */
-pub fn excluded_from_scan(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn excluded_from_scan(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "excludedFromScan", params)
+    super::call(service, "spider", "view", "excludedFromScan", params).await
 }
 
 /**
  * Returns a list of unique URLs from the history table based on HTTP messages added by the Spider.
 */
-pub fn all_urls(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn all_urls(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "allUrls", params)
+    super::call(service, "spider", "view", "allUrls", params).await
 }
 
 /**
  * Returns a list of the names of the nodes added to the Sites tree by the specified scan.
 */
-pub fn added_nodes(service: &ZapService, scanid: String) -> Result<Value, ZapApiError> {
+pub async fn added_nodes(service: &ZapService, scanid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanId".to_string(), scanid);
-    super::call(service, "spider", "view", "addedNodes", params)
+    params.insert("scanId".to_string(), scanid.to_string());
+    super::call(service, "spider", "view", "addedNodes", params).await
 }
 
 /**
  * Gets all the domains that are always in scope. For each domain the following are shown: the index, the value (domain), if enabled, and if specified as a regex.
 */
-pub fn domains_always_in_scope(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn domains_always_in_scope(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "domainsAlwaysInScope", params)
+    super::call(service, "spider", "view", "domainsAlwaysInScope", params).await
 }
 
 /**
  * Use view domainsAlwaysInScope instead.
- * Deprecated
 */
-pub fn option_domains_always_in_scope(service: &ZapService) -> Result<Value, ZapApiError> {
+#[deprecated]
+pub async fn option_domains_always_in_scope(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "spider",
-        "view",
-        "optionDomainsAlwaysInScope",
-        params,
-    )
+    super::call(service, "spider", "view", "optionDomainsAlwaysInScope", params).await
 }
 
 /**
  * Use view domainsAlwaysInScope instead.
- * Deprecated
 */
-pub fn option_domains_always_in_scope_enabled(service: &ZapService) -> Result<Value, ZapApiError> {
+#[deprecated]
+pub async fn option_domains_always_in_scope_enabled(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "spider",
-        "view",
-        "optionDomainsAlwaysInScopeEnabled",
-        params,
-    )
+    super::call(service, "spider", "view", "optionDomainsAlwaysInScopeEnabled", params).await
 }
 
-pub fn option_handle_parameters(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_handle_parameters(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "optionHandleParameters", params)
+    super::call(service, "spider", "view", "optionHandleParameters", params).await
 }
 
 /**
  * Gets the maximum number of child nodes (per node) that can be crawled, 0 means no limit.
 */
-pub fn option_max_children(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_max_children(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "optionMaxChildren", params)
+    super::call(service, "spider", "view", "optionMaxChildren", params).await
 }
 
 /**
  * Gets the maximum depth the spider can crawl, 0 if unlimited.
 */
-pub fn option_max_depth(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_max_depth(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "optionMaxDepth", params)
+    super::call(service, "spider", "view", "optionMaxDepth", params).await
 }
 
-pub fn option_max_duration(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_max_duration(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "optionMaxDuration", params)
+    super::call(service, "spider", "view", "optionMaxDuration", params).await
 }
 
 /**
  * Gets the maximum size, in bytes, that a response might have to be parsed.
 */
-pub fn option_max_parse_size_bytes(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_max_parse_size_bytes(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "optionMaxParseSizeBytes", params)
+    super::call(service, "spider", "view", "optionMaxParseSizeBytes", params).await
 }
 
-pub fn option_max_scans_in_ui(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_max_scans_in_ui(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "optionMaxScansInUI", params)
+    super::call(service, "spider", "view", "optionMaxScansInUI", params).await
 }
 
-pub fn option_request_wait_time(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_request_wait_time(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "optionRequestWaitTime", params)
+    super::call(service, "spider", "view", "optionRequestWaitTime", params).await
 }
 
-pub fn option_scope(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+#[deprecated(note="Option no longer in effective use.")]
+pub async fn option_scope(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "optionScope", params)
+    super::call(service, "spider", "view", "optionScope", params).await
 }
 
-pub fn option_scope_text(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+#[deprecated(note="Option no longer in effective use.")]
+pub async fn option_scope_text(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "optionScopeText", params)
+    super::call(service, "spider", "view", "optionScopeText", params).await
 }
 
-pub fn option_skip_url_string(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_skip_url_string(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "optionSkipURLString", params)
+    super::call(service, "spider", "view", "optionSkipURLString", params).await
 }
 
-pub fn option_thread_count(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_thread_count(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "optionThreadCount", params)
+    super::call(service, "spider", "view", "optionThreadCount", params).await
 }
 
-pub fn option_user_agent(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_user_agent(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "optionUserAgent", params)
+    super::call(service, "spider", "view", "optionUserAgent", params).await
 }
 
 /**
  * Gets whether or not a spider process should accept cookies while spidering.
 */
-pub fn option_accept_cookies(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_accept_cookies(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "optionAcceptCookies", params)
+    super::call(service, "spider", "view", "optionAcceptCookies", params).await
 }
 
-pub fn option_handle_o_data_parameters_visited(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_handle_o_data_parameters_visited(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "spider",
-        "view",
-        "optionHandleODataParametersVisited",
-        params,
-    )
+    super::call(service, "spider", "view", "optionHandleODataParametersVisited", params).await
 }
 
-pub fn option_parse_comments(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_parse_comments(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "optionParseComments", params)
+    super::call(service, "spider", "view", "optionParseComments", params).await
 }
 
-pub fn option_parse_git(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_parse_git(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "optionParseGit", params)
+    super::call(service, "spider", "view", "optionParseGit", params).await
 }
 
-pub fn option_parse_robots_txt(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_parse_robots_txt(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "optionParseRobotsTxt", params)
+    super::call(service, "spider", "view", "optionParseRobotsTxt", params).await
 }
 
-pub fn option_parse_svn_entries(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_parse_svn_entries(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "optionParseSVNEntries", params)
+    super::call(service, "spider", "view", "optionParseSVNEntries", params).await
 }
 
-pub fn option_parse_sitemap_xml(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_parse_sitemap_xml(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "optionParseSitemapXml", params)
+    super::call(service, "spider", "view", "optionParseSitemapXml", params).await
 }
 
-pub fn option_post_form(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_post_form(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "optionPostForm", params)
+    super::call(service, "spider", "view", "optionPostForm", params).await
 }
 
-pub fn option_process_form(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_process_form(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "optionProcessForm", params)
+    super::call(service, "spider", "view", "optionProcessForm", params).await
 }
 
 /**
  * Gets whether or not the 'Referer' header should be sent while spidering.
 */
-pub fn option_send_referer_header(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_send_referer_header(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "view", "optionSendRefererHeader", params)
+    super::call(service, "spider", "view", "optionSendRefererHeader", params).await
 }
 
-pub fn option_show_advanced_dialog(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn option_show_advanced_dialog(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "spider",
-        "view",
-        "optionShowAdvancedDialog",
-        params,
-    )
+    super::call(service, "spider", "view", "optionShowAdvancedDialog", params).await
 }
 
 /**
  * Runs the spider against the given URL (or context). Optionally, the 'maxChildren' parameter can be set to limit the number of children scanned, the 'recurse' parameter can be used to prevent the spider from seeding recursively, the parameter 'contextName' can be used to constrain the scan to a Context and the parameter 'subtreeOnly' allows to restrict the spider under a site's subtree (using the specified 'url').
 */
-pub fn scan(
-    service: &ZapService,
-    url: String,
-    maxchildren: String,
-    recurse: String,
-    contextname: String,
-    subtreeonly: String,
-) -> Result<Value, ZapApiError> {
+pub async fn scan(service: &ZapService, url: &str, maxchildren: &str, recurse: &str, contextname: &str, subtreeonly: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("url".to_string(), url);
-    params.insert("maxChildren".to_string(), maxchildren);
-    params.insert("recurse".to_string(), recurse);
-    params.insert("contextName".to_string(), contextname);
-    params.insert("subtreeOnly".to_string(), subtreeonly);
-    super::call(service, "spider", "action", "scan", params)
+    params.insert("url".to_string(), url.to_string());
+    params.insert("maxChildren".to_string(), maxchildren.to_string());
+    params.insert("recurse".to_string(), recurse.to_string());
+    params.insert("contextName".to_string(), contextname.to_string());
+    params.insert("subtreeOnly".to_string(), subtreeonly.to_string());
+    super::call(service, "spider", "action", "scan", params).await
 }
 
 /**
  * Runs the spider from the perspective of a User, obtained using the given Context ID and User ID. See 'scan' action for more details.
 */
-pub fn scan_as_user(
-    service: &ZapService,
-    contextid: String,
-    userid: String,
-    url: String,
-    maxchildren: String,
-    recurse: String,
-    subtreeonly: String,
-) -> Result<Value, ZapApiError> {
+pub async fn scan_as_user(service: &ZapService, contextid: &str, userid: &str, url: &str, maxchildren: &str, recurse: &str, subtreeonly: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    params.insert("userId".to_string(), userid);
-    params.insert("url".to_string(), url);
-    params.insert("maxChildren".to_string(), maxchildren);
-    params.insert("recurse".to_string(), recurse);
-    params.insert("subtreeOnly".to_string(), subtreeonly);
-    super::call(service, "spider", "action", "scanAsUser", params)
+    params.insert("contextId".to_string(), contextid.to_string());
+    params.insert("userId".to_string(), userid.to_string());
+    params.insert("url".to_string(), url.to_string());
+    params.insert("maxChildren".to_string(), maxchildren.to_string());
+    params.insert("recurse".to_string(), recurse.to_string());
+    params.insert("subtreeOnly".to_string(), subtreeonly.to_string());
+    super::call(service, "spider", "action", "scanAsUser", params).await
 }
 
-pub fn pause(service: &ZapService, scanid: String) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn pause(service: &ZapService, scanid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanId".to_string(), scanid);
-    super::call(service, "spider", "action", "pause", params)
+    params.insert("scanId".to_string(), scanid.to_string());
+    super::call(service, "spider", "action", "pause", params).await
 }
 
-pub fn resume(service: &ZapService, scanid: String) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn resume(service: &ZapService, scanid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanId".to_string(), scanid);
-    super::call(service, "spider", "action", "resume", params)
+    params.insert("scanId".to_string(), scanid.to_string());
+    super::call(service, "spider", "action", "resume", params).await
 }
 
-pub fn stop(service: &ZapService, scanid: String) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn stop(service: &ZapService, scanid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanId".to_string(), scanid);
-    super::call(service, "spider", "action", "stop", params)
+    params.insert("scanId".to_string(), scanid.to_string());
+    super::call(service, "spider", "action", "stop", params).await
 }
 
-pub fn remove_scan(service: &ZapService, scanid: String) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn remove_scan(service: &ZapService, scanid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("scanId".to_string(), scanid);
-    super::call(service, "spider", "action", "removeScan", params)
+    params.insert("scanId".to_string(), scanid.to_string());
+    super::call(service, "spider", "action", "removeScan", params).await
 }
 
-pub fn pause_all_scans(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn pause_all_scans(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "action", "pauseAllScans", params)
+    super::call(service, "spider", "action", "pauseAllScans", params).await
 }
 
-pub fn resume_all_scans(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn resume_all_scans(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "action", "resumeAllScans", params)
+    super::call(service, "spider", "action", "resumeAllScans", params).await
 }
 
-pub fn stop_all_scans(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn stop_all_scans(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "action", "stopAllScans", params)
+    super::call(service, "spider", "action", "stopAllScans", params).await
 }
 
-pub fn remove_all_scans(service: &ZapService) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn remove_all_scans(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "action", "removeAllScans", params)
+    super::call(service, "spider", "action", "removeAllScans", params).await
 }
 
 /**
  * Clears the regexes of URLs excluded from the spider scans.
 */
-pub fn clear_excluded_from_scan(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn clear_excluded_from_scan(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "spider", "action", "clearExcludedFromScan", params)
+    super::call(service, "spider", "action", "clearExcludedFromScan", params).await
 }
 
 /**
  * Adds a regex of URLs that should be excluded from the spider scans.
 */
-pub fn exclude_from_scan(service: &ZapService, regex: String) -> Result<Value, ZapApiError> {
+pub async fn exclude_from_scan(service: &ZapService, regex: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("regex".to_string(), regex);
-    super::call(service, "spider", "action", "excludeFromScan", params)
+    params.insert("regex".to_string(), regex.to_string());
+    super::call(service, "spider", "action", "excludeFromScan", params).await
 }
 
 /**
  * Adds a new domain that's always in scope, using the specified value. Optionally sets if the new entry is enabled (default, true) and whether or not the new value is specified as a regex (default, false).
 */
-pub fn add_domain_always_in_scope(
-    service: &ZapService,
-    value: String,
-    isregex: String,
-    isenabled: String,
-) -> Result<Value, ZapApiError> {
+pub async fn add_domain_always_in_scope(service: &ZapService, value: &str, isregex: &str, isenabled: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("value".to_string(), value);
-    params.insert("isRegex".to_string(), isregex);
-    params.insert("isEnabled".to_string(), isenabled);
-    super::call(
-        service,
-        "spider",
-        "action",
-        "addDomainAlwaysInScope",
-        params,
-    )
+    params.insert("value".to_string(), value.to_string());
+    params.insert("isRegex".to_string(), isregex.to_string());
+    params.insert("isEnabled".to_string(), isenabled.to_string());
+    super::call(service, "spider", "action", "addDomainAlwaysInScope", params).await
 }
 
 /**
  * Modifies a domain that's always in scope. Allows to modify the value, if enabled or if a regex. The domain is selected with its index, which can be obtained with the view domainsAlwaysInScope.
 */
-pub fn modify_domain_always_in_scope(
-    service: &ZapService,
-    idx: String,
-    value: String,
-    isregex: String,
-    isenabled: String,
-) -> Result<Value, ZapApiError> {
+pub async fn modify_domain_always_in_scope(service: &ZapService, idx: &str, value: &str, isregex: &str, isenabled: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("idx".to_string(), idx);
-    params.insert("value".to_string(), value);
-    params.insert("isRegex".to_string(), isregex);
-    params.insert("isEnabled".to_string(), isenabled);
-    super::call(
-        service,
-        "spider",
-        "action",
-        "modifyDomainAlwaysInScope",
-        params,
-    )
+    params.insert("idx".to_string(), idx.to_string());
+    params.insert("value".to_string(), value.to_string());
+    params.insert("isRegex".to_string(), isregex.to_string());
+    params.insert("isEnabled".to_string(), isenabled.to_string());
+    super::call(service, "spider", "action", "modifyDomainAlwaysInScope", params).await
 }
 
 /**
  * Removes a domain that's always in scope, with the given index. The index can be obtained with the view domainsAlwaysInScope.
 */
-pub fn remove_domain_always_in_scope(
-    service: &ZapService,
-    idx: String,
-) -> Result<Value, ZapApiError> {
+pub async fn remove_domain_always_in_scope(service: &ZapService, idx: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("idx".to_string(), idx);
-    super::call(
-        service,
-        "spider",
-        "action",
-        "removeDomainAlwaysInScope",
-        params,
-    )
+    params.insert("idx".to_string(), idx.to_string());
+    super::call(service, "spider", "action", "removeDomainAlwaysInScope", params).await
 }
 
 /**
  * Enables all domains that are always in scope.
 */
-pub fn enable_all_domains_always_in_scope(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn enable_all_domains_always_in_scope(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "spider",
-        "action",
-        "enableAllDomainsAlwaysInScope",
-        params,
-    )
+    super::call(service, "spider", "action", "enableAllDomainsAlwaysInScope", params).await
 }
 
 /**
  * Disables all domains that are always in scope.
 */
-pub fn disable_all_domains_always_in_scope(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn disable_all_domains_always_in_scope(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(
-        service,
-        "spider",
-        "action",
-        "disableAllDomainsAlwaysInScope",
-        params,
-    )
+    super::call(service, "spider", "action", "disableAllDomainsAlwaysInScope", params).await
 }
 
-pub fn set_option_handle_parameters(
-    service: &ZapService,
-    string: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_handle_parameters(service: &ZapService, string: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("String".to_string(), string);
-    super::call(
-        service,
-        "spider",
-        "action",
-        "setOptionHandleParameters",
-        params,
-    )
+    params.insert("String".to_string(), string.to_string());
+    super::call(service, "spider", "action", "setOptionHandleParameters", params).await
 }
 
 /**
  * Use actions [add|modify|remove]DomainAlwaysInScope instead.
- * Deprecated Option no longer in effective use.
 */
-pub fn set_option_scope_string(service: &ZapService, string: String) -> Result<Value, ZapApiError> {
+#[deprecated(note="Option no longer in effective use.")]
+pub async fn set_option_scope_string(service: &ZapService, string: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("String".to_string(), string);
-    super::call(service, "spider", "action", "setOptionScopeString", params)
+    params.insert("String".to_string(), string.to_string());
+    super::call(service, "spider", "action", "setOptionScopeString", params).await
 }
 
-pub fn set_option_skip_url_string(
-    service: &ZapService,
-    string: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_skip_url_string(service: &ZapService, string: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("String".to_string(), string);
-    super::call(
-        service,
-        "spider",
-        "action",
-        "setOptionSkipURLString",
-        params,
-    )
+    params.insert("String".to_string(), string.to_string());
+    super::call(service, "spider", "action", "setOptionSkipURLString", params).await
 }
 
-pub fn set_option_user_agent(service: &ZapService, string: String) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_user_agent(service: &ZapService, string: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("String".to_string(), string);
-    super::call(service, "spider", "action", "setOptionUserAgent", params)
+    params.insert("String".to_string(), string.to_string());
+    super::call(service, "spider", "action", "setOptionUserAgent", params).await
 }
 
 /**
  * Sets whether or not a spider process should accept cookies while spidering.
 */
-pub fn set_option_accept_cookies(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_option_accept_cookies(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "spider",
-        "action",
-        "setOptionAcceptCookies",
-        params,
-    )
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "spider", "action", "setOptionAcceptCookies", params).await
 }
 
-pub fn set_option_handle_o_data_parameters_visited(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_handle_o_data_parameters_visited(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "spider",
-        "action",
-        "setOptionHandleODataParametersVisited",
-        params,
-    )
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "spider", "action", "setOptionHandleODataParametersVisited", params).await
 }
 
 /**
  * Sets the maximum number of child nodes (per node) that can be crawled, 0 means no limit.
 */
-pub fn set_option_max_children(
-    service: &ZapService,
-    integer: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_option_max_children(service: &ZapService, integer: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Integer".to_string(), integer);
-    super::call(service, "spider", "action", "setOptionMaxChildren", params)
+    params.insert("Integer".to_string(), integer.to_string());
+    super::call(service, "spider", "action", "setOptionMaxChildren", params).await
 }
 
 /**
  * Sets the maximum depth the spider can crawl, 0 for unlimited depth.
 */
-pub fn set_option_max_depth(service: &ZapService, integer: String) -> Result<Value, ZapApiError> {
+pub async fn set_option_max_depth(service: &ZapService, integer: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Integer".to_string(), integer);
-    super::call(service, "spider", "action", "setOptionMaxDepth", params)
+    params.insert("Integer".to_string(), integer.to_string());
+    super::call(service, "spider", "action", "setOptionMaxDepth", params).await
 }
 
-pub fn set_option_max_duration(
-    service: &ZapService,
-    integer: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_max_duration(service: &ZapService, integer: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Integer".to_string(), integer);
-    super::call(service, "spider", "action", "setOptionMaxDuration", params)
+    params.insert("Integer".to_string(), integer.to_string());
+    super::call(service, "spider", "action", "setOptionMaxDuration", params).await
 }
 
 /**
  * Sets the maximum size, in bytes, that a response might have to be parsed. This allows the spider to skip big responses/files.
 */
-pub fn set_option_max_parse_size_bytes(
-    service: &ZapService,
-    integer: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_option_max_parse_size_bytes(service: &ZapService, integer: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Integer".to_string(), integer);
-    super::call(
-        service,
-        "spider",
-        "action",
-        "setOptionMaxParseSizeBytes",
-        params,
-    )
+    params.insert("Integer".to_string(), integer.to_string());
+    super::call(service, "spider", "action", "setOptionMaxParseSizeBytes", params).await
 }
 
-pub fn set_option_max_scans_in_ui(
-    service: &ZapService,
-    integer: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_max_scans_in_ui(service: &ZapService, integer: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Integer".to_string(), integer);
-    super::call(service, "spider", "action", "setOptionMaxScansInUI", params)
+    params.insert("Integer".to_string(), integer.to_string());
+    super::call(service, "spider", "action", "setOptionMaxScansInUI", params).await
 }
 
-pub fn set_option_parse_comments(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_parse_comments(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "spider",
-        "action",
-        "setOptionParseComments",
-        params,
-    )
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "spider", "action", "setOptionParseComments", params).await
 }
 
-pub fn set_option_parse_git(service: &ZapService, boolean: String) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_parse_git(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(service, "spider", "action", "setOptionParseGit", params)
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "spider", "action", "setOptionParseGit", params).await
 }
 
-pub fn set_option_parse_robots_txt(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_parse_robots_txt(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "spider",
-        "action",
-        "setOptionParseRobotsTxt",
-        params,
-    )
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "spider", "action", "setOptionParseRobotsTxt", params).await
 }
 
-pub fn set_option_parse_svn_entries(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_parse_svn_entries(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "spider",
-        "action",
-        "setOptionParseSVNEntries",
-        params,
-    )
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "spider", "action", "setOptionParseSVNEntries", params).await
 }
 
-pub fn set_option_parse_sitemap_xml(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_parse_sitemap_xml(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "spider",
-        "action",
-        "setOptionParseSitemapXml",
-        params,
-    )
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "spider", "action", "setOptionParseSitemapXml", params).await
 }
 
-pub fn set_option_post_form(service: &ZapService, boolean: String) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_post_form(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(service, "spider", "action", "setOptionPostForm", params)
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "spider", "action", "setOptionPostForm", params).await
 }
 
-pub fn set_option_process_form(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_process_form(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(service, "spider", "action", "setOptionProcessForm", params)
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "spider", "action", "setOptionProcessForm", params).await
 }
 
-pub fn set_option_request_wait_time(
-    service: &ZapService,
-    integer: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_request_wait_time(service: &ZapService, integer: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Integer".to_string(), integer);
-    super::call(
-        service,
-        "spider",
-        "action",
-        "setOptionRequestWaitTime",
-        params,
-    )
+    params.insert("Integer".to_string(), integer.to_string());
+    super::call(service, "spider", "action", "setOptionRequestWaitTime", params).await
 }
 
 /**
  * Sets whether or not the 'Referer' header should be sent while spidering.
 */
-pub fn set_option_send_referer_header(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_option_send_referer_header(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "spider",
-        "action",
-        "setOptionSendRefererHeader",
-        params,
-    )
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "spider", "action", "setOptionSendRefererHeader", params).await
 }
 
-pub fn set_option_show_advanced_dialog(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_show_advanced_dialog(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "spider",
-        "action",
-        "setOptionShowAdvancedDialog",
-        params,
-    )
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "spider", "action", "setOptionShowAdvancedDialog", params).await
 }
 
-pub fn set_option_thread_count(
-    service: &ZapService,
-    integer: String,
-) -> Result<Value, ZapApiError> {
+/**
+ * 
+*/
+pub async fn set_option_thread_count(service: &ZapService, integer: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Integer".to_string(), integer);
-    super::call(service, "spider", "action", "setOptionThreadCount", params)
+    params.insert("Integer".to_string(), integer.to_string());
+    super::call(service, "spider", "action", "setOptionThreadCount", params).await
 }
+

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 the ZAP development team
+ * Copyright 2020 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
  * limitations under the License.
  */
 
+
 use super::ZapApiError;
 use super::ZapService;
 use serde_json::Value;
 use std::collections::HashMap;
+
 
 /**
  * This file was automatically generated.
@@ -28,128 +30,113 @@ use std::collections::HashMap;
 /**
  * Statistics
 */
-pub fn stats(service: &ZapService, keyprefix: String) -> Result<Value, ZapApiError> {
+pub async fn stats(service: &ZapService, keyprefix: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("keyPrefix".to_string(), keyprefix);
-    super::call(service, "stats", "view", "stats", params)
+    params.insert("keyPrefix".to_string(), keyprefix.to_string());
+    super::call(service, "stats", "view", "stats", params).await
 }
 
 /**
  * Gets all of the site based statistics, optionally filtered by a key prefix
 */
-pub fn all_sites_stats(service: &ZapService, keyprefix: String) -> Result<Value, ZapApiError> {
+pub async fn all_sites_stats(service: &ZapService, keyprefix: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("keyPrefix".to_string(), keyprefix);
-    super::call(service, "stats", "view", "allSitesStats", params)
+    params.insert("keyPrefix".to_string(), keyprefix.to_string());
+    super::call(service, "stats", "view", "allSitesStats", params).await
 }
 
 /**
  * Gets all of the global statistics, optionally filtered by a key prefix
 */
-pub fn site_stats(
-    service: &ZapService,
-    site: String,
-    keyprefix: String,
-) -> Result<Value, ZapApiError> {
+pub async fn site_stats(service: &ZapService, site: &str, keyprefix: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("site".to_string(), site);
-    params.insert("keyPrefix".to_string(), keyprefix);
-    super::call(service, "stats", "view", "siteStats", params)
+    params.insert("site".to_string(), site.to_string());
+    params.insert("keyPrefix".to_string(), keyprefix.to_string());
+    super::call(service, "stats", "view", "siteStats", params).await
 }
 
 /**
  * Gets the Statsd service hostname
 */
-pub fn option_statsd_host(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_statsd_host(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "stats", "view", "optionStatsdHost", params)
+    super::call(service, "stats", "view", "optionStatsdHost", params).await
 }
 
 /**
  * Gets the Statsd service port
 */
-pub fn option_statsd_port(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_statsd_port(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "stats", "view", "optionStatsdPort", params)
+    super::call(service, "stats", "view", "optionStatsdPort", params).await
 }
 
 /**
  * Gets the prefix to be applied to all stats sent to the configured Statsd service
 */
-pub fn option_statsd_prefix(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_statsd_prefix(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "stats", "view", "optionStatsdPrefix", params)
+    super::call(service, "stats", "view", "optionStatsdPrefix", params).await
 }
 
 /**
  * Returns 'true' if in memory statistics are enabled, otherwise returns 'false'
 */
-pub fn option_in_memory_enabled(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_in_memory_enabled(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "stats", "view", "optionInMemoryEnabled", params)
+    super::call(service, "stats", "view", "optionInMemoryEnabled", params).await
 }
 
 /**
  * Returns 'true' if a Statsd server has been correctly configured, otherwise returns 'false'
 */
-pub fn option_statsd_enabled(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn option_statsd_enabled(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "stats", "view", "optionStatsdEnabled", params)
+    super::call(service, "stats", "view", "optionStatsdEnabled", params).await
 }
 
 /**
  * Clears all of the statistics
 */
-pub fn clear_stats(service: &ZapService, keyprefix: String) -> Result<Value, ZapApiError> {
+pub async fn clear_stats(service: &ZapService, keyprefix: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("keyPrefix".to_string(), keyprefix);
-    super::call(service, "stats", "action", "clearStats", params)
+    params.insert("keyPrefix".to_string(), keyprefix.to_string());
+    super::call(service, "stats", "action", "clearStats", params).await
 }
 
 /**
  * Sets the Statsd service hostname, supply an empty string to stop using a Statsd service
 */
-pub fn set_option_statsd_host(service: &ZapService, string: String) -> Result<Value, ZapApiError> {
+pub async fn set_option_statsd_host(service: &ZapService, string: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("String".to_string(), string);
-    super::call(service, "stats", "action", "setOptionStatsdHost", params)
+    params.insert("String".to_string(), string.to_string());
+    super::call(service, "stats", "action", "setOptionStatsdHost", params).await
 }
 
 /**
  * Sets the prefix to be applied to all stats sent to the configured Statsd service
 */
-pub fn set_option_statsd_prefix(
-    service: &ZapService,
-    string: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_option_statsd_prefix(service: &ZapService, string: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("String".to_string(), string);
-    super::call(service, "stats", "action", "setOptionStatsdPrefix", params)
+    params.insert("String".to_string(), string.to_string());
+    super::call(service, "stats", "action", "setOptionStatsdPrefix", params).await
 }
 
 /**
  * Sets whether in memory statistics are enabled
 */
-pub fn set_option_in_memory_enabled(
-    service: &ZapService,
-    boolean: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_option_in_memory_enabled(service: &ZapService, boolean: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Boolean".to_string(), boolean);
-    super::call(
-        service,
-        "stats",
-        "action",
-        "setOptionInMemoryEnabled",
-        params,
-    )
+    params.insert("Boolean".to_string(), boolean.to_string());
+    super::call(service, "stats", "action", "setOptionInMemoryEnabled", params).await
 }
 
 /**
  * Sets the Statsd service port
 */
-pub fn set_option_statsd_port(service: &ZapService, integer: String) -> Result<Value, ZapApiError> {
+pub async fn set_option_statsd_port(service: &ZapService, integer: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("Integer".to_string(), integer);
-    super::call(service, "stats", "action", "setOptionStatsdPort", params)
+    params.insert("Integer".to_string(), integer.to_string());
+    super::call(service, "stats", "action", "setOptionStatsdPort", params).await
 }
+

--- a/src/users.rs
+++ b/src/users.rs
@@ -2,7 +2,7 @@
  *
  * ZAP is an HTTP/HTTPS proxy for assessing web application security.
  *
- * Copyright 2019 the ZAP development team
+ * Copyright 2020 the ZAP development team
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
  * limitations under the License.
  */
 
+
 use super::ZapApiError;
 use super::ZapService;
 use serde_json::Value;
 use std::collections::HashMap;
+
 
 /**
  * This file was automatically generated.
@@ -28,145 +30,91 @@ use std::collections::HashMap;
 /**
  * Gets a list of users that belong to the context with the given ID, or all users if none provided.
 */
-pub fn users_list(service: &ZapService, contextid: String) -> Result<Value, ZapApiError> {
+pub async fn users_list(service: &ZapService, contextid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    super::call(service, "users", "view", "usersList", params)
+    params.insert("contextId".to_string(), contextid.to_string());
+    super::call(service, "users", "view", "usersList", params).await
 }
 
 /**
  * Gets the data of the user with the given ID that belongs to the context with the given ID.
 */
-pub fn get_user_by_id(
-    service: &ZapService,
-    contextid: String,
-    userid: String,
-) -> Result<Value, ZapApiError> {
+pub async fn get_user_by_id(service: &ZapService, contextid: &str, userid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    params.insert("userId".to_string(), userid);
-    super::call(service, "users", "view", "getUserById", params)
+    params.insert("contextId".to_string(), contextid.to_string());
+    params.insert("userId".to_string(), userid.to_string());
+    super::call(service, "users", "view", "getUserById", params).await
 }
 
 /**
  * Gets the configuration parameters for the credentials of the context with the given ID.
 */
-pub fn get_authentication_credentials_config_params(
-    service: &ZapService,
-    contextid: String,
-) -> Result<Value, ZapApiError> {
+pub async fn get_authentication_credentials_config_params(service: &ZapService, contextid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    super::call(
-        service,
-        "users",
-        "view",
-        "getAuthenticationCredentialsConfigParams",
-        params,
-    )
+    params.insert("contextId".to_string(), contextid.to_string());
+    super::call(service, "users", "view", "getAuthenticationCredentialsConfigParams", params).await
 }
 
 /**
  * Gets the authentication credentials of the user with given ID that belongs to the context with the given ID.
 */
-pub fn get_authentication_credentials(
-    service: &ZapService,
-    contextid: String,
-    userid: String,
-) -> Result<Value, ZapApiError> {
+pub async fn get_authentication_credentials(service: &ZapService, contextid: &str, userid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    params.insert("userId".to_string(), userid);
-    super::call(
-        service,
-        "users",
-        "view",
-        "getAuthenticationCredentials",
-        params,
-    )
+    params.insert("contextId".to_string(), contextid.to_string());
+    params.insert("userId".to_string(), userid.to_string());
+    super::call(service, "users", "view", "getAuthenticationCredentials", params).await
 }
 
 /**
  * Creates a new user with the given name for the context with the given ID.
 */
-pub fn new_user(
-    service: &ZapService,
-    contextid: String,
-    name: String,
-) -> Result<Value, ZapApiError> {
+pub async fn new_user(service: &ZapService, contextid: &str, name: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    params.insert("name".to_string(), name);
-    super::call(service, "users", "action", "newUser", params)
+    params.insert("contextId".to_string(), contextid.to_string());
+    params.insert("name".to_string(), name.to_string());
+    super::call(service, "users", "action", "newUser", params).await
 }
 
 /**
  * Removes the user with the given ID that belongs to the context with the given ID.
 */
-pub fn remove_user(
-    service: &ZapService,
-    contextid: String,
-    userid: String,
-) -> Result<Value, ZapApiError> {
+pub async fn remove_user(service: &ZapService, contextid: &str, userid: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    params.insert("userId".to_string(), userid);
-    super::call(service, "users", "action", "removeUser", params)
+    params.insert("contextId".to_string(), contextid.to_string());
+    params.insert("userId".to_string(), userid.to_string());
+    super::call(service, "users", "action", "removeUser", params).await
 }
 
 /**
  * Sets whether or not the user, with the given ID that belongs to the context with the given ID, should be enabled.
 */
-pub fn set_user_enabled(
-    service: &ZapService,
-    contextid: String,
-    userid: String,
-    enabled: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_user_enabled(service: &ZapService, contextid: &str, userid: &str, enabled: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    params.insert("userId".to_string(), userid);
-    params.insert("enabled".to_string(), enabled);
-    super::call(service, "users", "action", "setUserEnabled", params)
+    params.insert("contextId".to_string(), contextid.to_string());
+    params.insert("userId".to_string(), userid.to_string());
+    params.insert("enabled".to_string(), enabled.to_string());
+    super::call(service, "users", "action", "setUserEnabled", params).await
 }
 
 /**
  * Renames the user with the given ID that belongs to the context with the given ID.
 */
-pub fn set_user_name(
-    service: &ZapService,
-    contextid: String,
-    userid: String,
-    name: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_user_name(service: &ZapService, contextid: &str, userid: &str, name: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    params.insert("userId".to_string(), userid);
-    params.insert("name".to_string(), name);
-    super::call(service, "users", "action", "setUserName", params)
+    params.insert("contextId".to_string(), contextid.to_string());
+    params.insert("userId".to_string(), userid.to_string());
+    params.insert("name".to_string(), name.to_string());
+    super::call(service, "users", "action", "setUserName", params).await
 }
 
 /**
  * Sets the authentication credentials for the user with the given ID that belongs to the context with the given ID.
 */
-pub fn set_authentication_credentials(
-    service: &ZapService,
-    contextid: String,
-    userid: String,
-    authcredentialsconfigparams: String,
-) -> Result<Value, ZapApiError> {
+pub async fn set_authentication_credentials(service: &ZapService, contextid: &str, userid: &str, authcredentialsconfigparams: &str) -> Result<Value, ZapApiError> {
     let mut params = HashMap::new();
-    params.insert("contextId".to_string(), contextid);
-    params.insert("userId".to_string(), userid);
-    params.insert(
-        "authCredentialsConfigParams".to_string(),
-        authcredentialsconfigparams,
-    );
-    super::call(
-        service,
-        "users",
-        "action",
-        "setAuthenticationCredentials",
-        params,
-    )
+    params.insert("contextId".to_string(), contextid.to_string());
+    params.insert("userId".to_string(), userid.to_string());
+    params.insert("authCredentialsConfigParams".to_string(), authcredentialsconfigparams.to_string());
+    super::call(service, "users", "action", "setAuthenticationCredentials", params).await
 }
+

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -23,16 +23,13 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 /**
- * This file was automatically generated.
- */
-/**
  * Returns all of the registered web socket channels
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn channels(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn channels(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "websocket", "view", "channels", params)
+    super::call(service, "websocket", "view", "channels", params).await
 }
 
 /**
@@ -40,7 +37,7 @@ pub fn channels(service: &ZapService) -> Result<Value, ZapApiError> {
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn message(
+pub async fn message(
     service: &ZapService,
     channelid: String,
     messageid: String,
@@ -48,7 +45,7 @@ pub fn message(
     let mut params = HashMap::new();
     params.insert("channelId".to_string(), channelid);
     params.insert("messageId".to_string(), messageid);
-    super::call(service, "websocket", "view", "message", params)
+    super::call(service, "websocket", "view", "message", params).await
 }
 
 /**
@@ -56,7 +53,7 @@ pub fn message(
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn messages(
+pub async fn messages(
     service: &ZapService,
     channelid: String,
     start: String,
@@ -68,7 +65,7 @@ pub fn messages(
     params.insert("start".to_string(), start);
     params.insert("count".to_string(), count);
     params.insert("payloadPreviewLength".to_string(), payloadpreviewlength);
-    super::call(service, "websocket", "view", "messages", params)
+    super::call(service, "websocket", "view", "messages", params).await
 }
 
 /**
@@ -76,9 +73,9 @@ pub fn messages(
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn break_text_message(service: &ZapService) -> Result<Value, ZapApiError> {
+pub async fn break_text_message(service: &ZapService) -> Result<Value, ZapApiError> {
     let params = HashMap::new();
-    super::call(service, "websocket", "view", "breakTextMessage", params)
+    super::call(service, "websocket", "view", "breakTextMessage", params).await
 }
 
 /**
@@ -86,7 +83,7 @@ pub fn break_text_message(service: &ZapService) -> Result<Value, ZapApiError> {
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn send_text_message(
+pub async fn send_text_message(
     service: &ZapService,
     channelid: String,
     outgoing: String,
@@ -96,7 +93,7 @@ pub fn send_text_message(
     params.insert("channelId".to_string(), channelid);
     params.insert("outgoing".to_string(), outgoing);
     params.insert("message".to_string(), message);
-    super::call(service, "websocket", "action", "sendTextMessage", params)
+    super::call(service, "websocket", "action", "sendTextMessage", params).await
 }
 
 /**
@@ -104,7 +101,7 @@ pub fn send_text_message(
  * <p>
  * This component is optional and therefore the API will only work if it is installed
 */
-pub fn set_break_text_message(
+pub async fn set_break_text_message(
     service: &ZapService,
     message: String,
     outgoing: String,
@@ -119,4 +116,5 @@ pub fn set_break_text_message(
         "setBreakTextMessage",
         params,
     )
+    .await
 }


### PR DESCRIPTION
Update Rust API:
- to utilize async / .await
   - request v.10
- Update example to include scanning and alerts

The following files were manually updated, and assistance/guidance may be needed to auto-generate plugins (@thc202)
- ajax_spider
- alert_filter
- import_log_files
- importurls
- openapi
- replacer
- reveal
- selenium
- soap
- websocket


PR to main ZAP repo for Rust API generation: https://github.com/zaproxy/zaproxy/pull/6227