### PR TITLE
Update names and link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,9 +3,9 @@ name = "zap_api"
 version = "0.0.2"
 authors = ["Simon Bennetts <psiinon@gmail.com>"]
 edition = "2018"
-description = "The Rust implementation to access the OWASP ZAP API"
+description = "The Rust implementation to access the ZAP API"
 repository = "https://github.com/zaproxy/zap-api-rust"
-keywords = ["owasp", "zap", "zaproxy", "api"]
+keywords = ["zap", "zaproxy", "api"]
 license = "Apache-2.0"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# OWASP ZAP Rust API
+# ZAP Rust API
 
-The Rust implementation to access the [OWASP ZAP API](https://github.com/zaproxy/zaproxy/wiki/ApiDetails). For more information
-about OWASP ZAP consult the (main) [OWASP ZAP project](https://github.com/zaproxy/zaproxy/).
+The Rust implementation to access the [ZAP API](https://www.zaproxy.org/docs/api/). For more information
+about ZAP consult the (main) [ZAP project](https://github.com/zaproxy/zaproxy/).
 
 This project is at a very early stage and should not be used in production!
 
 ## Getting Help
 
-For help using OWASP ZAP API refer to:
+For help using ZAP API refer to:
   * [Examples](examples) - collection of examples using the library;
   * [API Documentation](https://www.zaproxy.org/docs/api/);
-  * [OWASP ZAP User Group](https://groups.google.com/group/zaproxy-users) - for asking questions;
+  * [ZAP User Group](https://groups.google.com/group/zaproxy-users) - for asking questions;
   
 ## Issues
 
-To report issues related to OWASP ZAP API, bugs and enhancements requests, use the [issue tracker of the main OWASP ZAP project](https://github.com/zaproxy/zaproxy/issues).
+To report issues related to ZAP API, bugs and enhancements requests, use the [issue tracker of the main ZAP project](https://github.com/zaproxy/zaproxy/issues).
 
 ## Building
 


### PR DESCRIPTION
Remove OWASP references.
Link to API docs instead of outdated wiki page.